### PR TITLE
Include deps.ts in NPM package published files

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
 	"name": "svelte-adapter-deno",
-	"version": "0.1.0",
+	"version": "0.2.1",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
-			"version": "0.1.0",
+			"version": "0.2.1",
 			"devDependencies": {
 				"@rollup/plugin-commonjs": "^17.1.0",
 				"@rollup/plugin-json": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "svelte-adapter-deno",
-	"version": "0.2.0",
+	"version": "0.2.1",
 	"type": "module",
 	"exports": {
 		"import": "./index.js"
@@ -9,7 +9,8 @@
 	"types": "index.d.ts",
 	"files": [
 		"files",
-		"index.d.ts"
+		"index.d.ts",
+		"deps.ts"
 	],
 	"scripts": {
 		"dev": "rollup -cw",


### PR DESCRIPTION
Addresses https://github.com/pluvial/svelte-adapter-deno/issues/3, adds `deps.ts` to the published NPM package.