### PR TITLE
Sync with upstream changes

### DIFF
--- a/deps.ts
+++ b/deps.ts
@@ -1,3 +1,3 @@
-export { existsSync } from 'https://deno.land/std@0.95.0/fs/exists.ts';
-export { dirname, fromFileUrl, join } from 'https://deno.land/std@0.95.0/path/mod.ts';
-export { opine as app, serveStatic } from 'https://deno.land/x/opine@1.3.3/mod.ts';
+export { existsSync } from 'https://deno.land/std@0.106.0/fs/exists.ts';
+export { dirname, fromFileUrl, join } from 'https://deno.land/std@0.106.0/path/mod.ts';
+export { opine as app, serveStatic } from 'https://deno.land/x/opine@1.7.2/mod.ts';

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,3 +1,17 @@
-declare function plugin(options: { out?: string }): import('@sveltejs/kit').Adapter;
+import { Adapter } from '@sveltejs/kit';
+import { BuildOptions } from 'esbuild';
 
+interface AdapterOptions {
+	out?: string;
+	precompress?: boolean;
+	env?: {
+		path?: string;
+		host?: string;
+		port?: string;
+	};
+	esbuild?: (options: BuildOptions) => Promise<BuildOptions> | BuildOptions;
+	deps?: string;
+}
+
+declare function plugin(options?: AdapterOptions): Adapter;
 export = plugin;

--- a/index.js
+++ b/index.js
@@ -2,24 +2,39 @@ import { join } from 'path';
 import { fileURLToPath } from 'url';
 import esbuild from 'esbuild';
 
+import {
+	createReadStream,
+	createWriteStream,
+	existsSync,
+	// readFileSync,
+	statSync,
+	writeFileSync
+} from 'fs';
+import { pipeline } from 'stream';
+import glob from 'tiny-glob';
+import { promisify } from 'util';
+import zlib from 'zlib';
+
+const pipe = promisify(pipeline);
+
 /**
- * @param {{
- *   out?: string;
- *   deps?: string;
- * }} options
+ * @typedef {import('esbuild').BuildOptions} BuildOptions
  */
+
+/** @type {import('.')} */
 export default function ({
 	out = 'build',
+	precompress,
+	env: { path: path_env = 'SOCKET_PATH', host: host_env = 'HOST', port: port_env = 'PORT' } = {},
+	esbuild: esbuildConfig,
 	deps = fileURLToPath(new URL('./deps.ts', import.meta.url))
 } = {}) {
-	/** @type {import('@sveltejs/kit').Adapter} */
-	const adapter = {
+	return {
 		name: 'svelte-adapter-deno',
 
-		async adapt({ utils }) {
+		async adapt({ utils, config }) {
 			const dirs = {
 				files: fileURLToPath(new URL('./files', import.meta.url)),
-				server: join('.svelte-kit', 'output', 'server'),
 				static: join(out, 'assets')
 			};
 
@@ -27,28 +42,90 @@ export default function ({
 			utils.copy_client_files(dirs.static);
 			utils.copy_static_files(dirs.static);
 
-			utils.log.minor('Bundling application server');
-			await esbuild.build({
-				entryPoints: [join(dirs.server, 'app.js')],
-				outfile: join(out, 'app.js'),
-				bundle: true,
-				// platform: 'browser'
-				platform: 'neutral',
-				sourcemap: 'external'
-			});
-
-			utils.log.minor('Copying server files');
-			utils.copy(dirs.files, out);
+			if (precompress) {
+				utils.log.minor('Compressing assets');
+				await compress(dirs.static);
+			}
 
 			utils.log.minor(`Copying deps.ts: ${deps}`);
-			utils.copy(deps, join(out, 'deps.ts'));
+			utils.copy(deps, '.svelte-kit/deno/deps.ts');
+
+			utils.log.minor('Building server');
+			utils.copy(dirs.files, '.svelte-kit/deno');
+			writeFileSync(
+				'.svelte-kit/deno/env.js',
+				`export const path = Deno.env.get(${JSON.stringify(
+					path_env
+				)}) ?? false;\nexport const host = Deno.env.get(${JSON.stringify(
+					host_env
+				)}) ?? '0.0.0.0';\nexport const port = Deno.env.get(${JSON.stringify(
+					port_env
+				)}) ?? (!path && 3000);`
+			);
+			/** @type {BuildOptions} */
+			const defaultOptions = {
+				entryPoints: ['.svelte-kit/deno/index.js'],
+				outfile: join(out, 'index.js'),
+				bundle: true,
+				// external: Object.keys(JSON.parse(readFileSync('package.json', 'utf8')).dependencies || {}),
+				format: 'esm',
+				// platform: 'browser'
+				platform: 'neutral',
+				// inject: [join(dirs.files, 'shims.js')],
+				define: {
+					APP_DIR: `"/${config.kit.appDir}/"`
+				},
+				sourcemap: 'external'
+			};
+			const buildOptions = esbuildConfig ? await esbuildConfig(defaultOptions) : defaultOptions;
+			await esbuild.build(buildOptions);
 
 			utils.log.minor('Prerendering static pages');
 			await utils.prerender({
 				dest: `${out}/prerendered`
 			});
+			if (precompress && existsSync(`${out}/prerendered`)) {
+				utils.log.minor('Compressing prerendered pages');
+				await compress(`${out}/prerendered`);
+			}
 		}
 	};
+}
 
-	return adapter;
+/**
+ * @param {string} directory
+ */
+async function compress(directory) {
+	const files = await glob('**/*.{html,js,json,css,svg,xml}', {
+		cwd: directory,
+		dot: true,
+		absolute: true,
+		filesOnly: true
+	});
+
+	await Promise.all(
+		files.map((file) => Promise.all([compress_file(file, 'gz'), compress_file(file, 'br')]))
+	);
+}
+
+/**
+ * @param {string} file
+ * @param {'gz' | 'br'} format
+ */
+async function compress_file(file, format = 'gz') {
+	const compress =
+		format == 'br'
+			? zlib.createBrotliCompress({
+					params: {
+						[zlib.constants.BROTLI_PARAM_MODE]: zlib.constants.BROTLI_MODE_TEXT,
+						[zlib.constants.BROTLI_PARAM_QUALITY]: zlib.constants.BROTLI_MAX_QUALITY,
+						[zlib.constants.BROTLI_PARAM_SIZE_HINT]: statSync(file).size
+					}
+			  })
+			: zlib.createGzip({ level: zlib.constants.Z_BEST_COMPRESSION });
+
+	const source = createReadStream(file);
+	const destination = createWriteStream(`${file}.${format}`);
+
+	await pipe(source, compress, destination);
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,12 @@
 	"requires": true,
 	"packages": {
 		"": {
+			"name": "svelte-adapter-deno",
 			"version": "0.2.1",
+			"dependencies": {
+				"esbuild": "^0.12.5",
+				"tiny-glob": "^0.2.9"
+			},
 			"devDependencies": {
 				"@rollup/plugin-commonjs": "^17.1.0",
 				"@rollup/plugin-json": "^4.1.0",
@@ -953,7 +958,6 @@
 			"version": "0.12.15",
 			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.12.15.tgz",
 			"integrity": "sha512-72V4JNd2+48eOVCXx49xoSWHgC3/cCy96e7mbXKY+WOWghN00cCmlGnwVLRhRHorvv0dgCyuMYBZlM2xDM5OQw==",
-			"dev": true,
 			"hasInstallScript": true,
 			"bin": {
 				"esbuild": "bin/esbuild"
@@ -1615,6 +1619,11 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/globalyzer": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/globalyzer/-/globalyzer-0.1.0.tgz",
+			"integrity": "sha512-40oNTM9UfG6aBmuKxk/giHn5nQ8RVz/SS4Ir6zgzOv9/qC3kKZ9v4etGTcJbEl/NyVQH7FGU7d+X1egr57Md2Q=="
+		},
 		"node_modules/globby": {
 			"version": "11.0.4",
 			"resolved": "https://registry.npmjs.org/globby/-/globby-11.0.4.tgz",
@@ -1643,6 +1652,11 @@
 			"engines": {
 				"node": ">= 4"
 			}
+		},
+		"node_modules/globrex": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/globrex/-/globrex-0.1.2.tgz",
+			"integrity": "sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg=="
 		},
 		"node_modules/graceful-fs": {
 			"version": "4.2.6",
@@ -2904,6 +2918,15 @@
 			"integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
 			"dev": true
 		},
+		"node_modules/tiny-glob": {
+			"version": "0.2.9",
+			"resolved": "https://registry.npmjs.org/tiny-glob/-/tiny-glob-0.2.9.tgz",
+			"integrity": "sha512-g/55ssRPUjShh+xkfx9UPDXqhckHEsHr4Vd9zX55oSdGZc/MD0m3sferOkwWtp98bv+kcVfEHtRJgBVJzelrzg==",
+			"dependencies": {
+				"globalyzer": "0.1.0",
+				"globrex": "^0.1.2"
+			}
+		},
 		"node_modules/to-regex-range": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -3768,8 +3791,7 @@
 		"esbuild": {
 			"version": "0.12.15",
 			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.12.15.tgz",
-			"integrity": "sha512-72V4JNd2+48eOVCXx49xoSWHgC3/cCy96e7mbXKY+WOWghN00cCmlGnwVLRhRHorvv0dgCyuMYBZlM2xDM5OQw==",
-			"dev": true
+			"integrity": "sha512-72V4JNd2+48eOVCXx49xoSWHgC3/cCy96e7mbXKY+WOWghN00cCmlGnwVLRhRHorvv0dgCyuMYBZlM2xDM5OQw=="
 		},
 		"escape-string-regexp": {
 			"version": "4.0.0",
@@ -4280,6 +4302,11 @@
 				"type-fest": "^0.20.2"
 			}
 		},
+		"globalyzer": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/globalyzer/-/globalyzer-0.1.0.tgz",
+			"integrity": "sha512-40oNTM9UfG6aBmuKxk/giHn5nQ8RVz/SS4Ir6zgzOv9/qC3kKZ9v4etGTcJbEl/NyVQH7FGU7d+X1egr57Md2Q=="
+		},
 		"globby": {
 			"version": "11.0.4",
 			"resolved": "https://registry.npmjs.org/globby/-/globby-11.0.4.tgz",
@@ -4301,6 +4328,11 @@
 					"dev": true
 				}
 			}
+		},
+		"globrex": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/globrex/-/globrex-0.1.2.tgz",
+			"integrity": "sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg=="
 		},
 		"graceful-fs": {
 			"version": "4.2.6",
@@ -5213,6 +5245,15 @@
 			"resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
 			"integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
 			"dev": true
+		},
+		"tiny-glob": {
+			"version": "0.2.9",
+			"resolved": "https://registry.npmjs.org/tiny-glob/-/tiny-glob-0.2.9.tgz",
+			"integrity": "sha512-g/55ssRPUjShh+xkfx9UPDXqhckHEsHr4Vd9zX55oSdGZc/MD0m3sferOkwWtp98bv+kcVfEHtRJgBVJzelrzg==",
+			"requires": {
+				"globalyzer": "0.1.0",
+				"globrex": "^0.1.2"
+			}
 		},
 		"to-regex-range": {
 			"version": "5.0.1",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,9 @@
 {
 	"name": "svelte-adapter-deno",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/pluvial/svelte-adapter-deno.git"
+	},
 	"version": "0.2.1",
 	"type": "module",
 	"exports": {
@@ -7,11 +11,7 @@
 	},
 	"main": "index.js",
 	"types": "index.d.ts",
-	"files": [
-		"files",
-		"index.d.ts",
-		"deps.ts"
-	],
+	"files": ["files", "index.d.ts", "deps.ts"],
 	"scripts": {
 		"dev": "rollup -cw",
 		"build": "rollup -c",
@@ -19,6 +19,10 @@
 		"format": "prettier --write . --ignore-path .gitignore",
 		"check-format": "prettier --check . --ignore-path .gitignore",
 		"prepublishOnly": "npm run build"
+	},
+	"dependencies": {
+		"esbuild": "^0.12.5",
+		"tiny-glob": "^0.2.9"
 	},
 	"devDependencies": {
 		"@rollup/plugin-commonjs": "^17.1.0",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -5,10 +5,10 @@ import json from '@rollup/plugin-json';
 export default {
 	input: 'src/index.js',
 	output: {
-		file: 'files/server.js',
+		file: 'files/index.js',
 		format: 'esm',
 		sourcemap: true
 	},
 	plugins: [nodeResolve(), commonjs(), json()],
-	external: ['./app.js', './deps.ts', ...require('module').builtinModules]
+	external: ['../output/server/app.js', './deps.ts', './env.js', ...require('module').builtinModules]
 };

--- a/src/http.js
+++ b/src/http.js
@@ -1,6 +1,6 @@
-import { readAll } from 'https://deno.land/std@0.95.0/io/mod.ts';
+import { readAll } from 'https://deno.land/std@0.106.0/io/mod.ts';
 
-// import type { ServerRequest } from 'https://deno.land/std@0.95.0/http/server.ts';
+// import type { ServerRequest } from 'https://deno.land/std@0.106.0/http/server.ts';
 
 /**
  * Converts request headers from Headers to a plain key-value object, as used in node
@@ -11,7 +11,7 @@ export const headers_to_object = (headers) => Object.fromEntries(headers.entries
 
 /**
  * @param {ServerRequest} req Deno server request object
- * @returns {Promise<string>} Resolves with the request body decoded to a string
+ * @returns {Promise<null | Uint8Array>} Resolves with the request body raw buffer
  */
 export async function getRawBody(req) {
 	const { headers } = req;
@@ -23,13 +23,5 @@ export async function getRawBody(req) {
 	}
 
 	const data = await readAll(req.body);
-
-	// return raw buffer for octet-stream content-type
-	if (type === 'application/octet-stream') {
-		return data.buffer;
-	}
-
-	// decode the raw buffer into a string
-	const decoder = new TextDecoder(req.headers.get('content-encoding') ?? 'utf-8');
-	return decoder.decode(data);
+  return data;
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,14 +1,15 @@
+import { init, render } from '../output/server/app.js';
+import { path, host, port } from './env.js';
 import { createServer } from './server.js';
-import { render } from './app.js';
 
-const hostname = Deno.env.get('HOST') ?? '0.0.0.0';
-const port = Deno.env.get('PORT') ?? 3000;
+init();
 
-const instance = createServer({ render }).listen({ hostname, port }, (err) => {
+const addr = path || `${host}:${port}`;
+const instance = createServer({ render }).listen(addr, (err) => {
 	if (err) {
-		console.log('error', err);
+		console.error('error', err);
 	} else {
-		console.log(`Listening on port ${port}`);
+		console.log(`Listening on http://${addr}`);
 	}
 });
 


### PR DESCRIPTION
Update Deno runtime dependencies, in particular `opine`, addressing this issue: https://github.com/pluvial/svelte-adapter-deno/issues/5

Sync with the relevant upstream changes to `@sveltejs/adapter-node`, including the new `init()` call, and always returning the raw buffer from `getRawBody()`.

Resolves https://github.com/pluvial/svelte-adapter-deno/issues/7. resolves https://github.com/pluvial/svelte-adapter-deno/issues/8