### PR TITLE
Add tsconfig.deno.json and update documentation to fix upstream changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ export default {
 After building the server (`npm run build`), use the following command to start:
 
 ```sh
-$ deno run --allow-env --allow-read --allow-net path/to/build/server.js
+$ deno run --allow-env --allow-read --allow-net --config tsconfig.deno.json path/to/build/index.js
 ```
 
 The server needs at least the following permissions to run:
@@ -32,6 +32,15 @@ The server needs at least the following permissions to run:
 - `allow-env` - allow environment access, to support runtime configuration via runtime variables (can be further restricted to include just the necessary variables)
 - `allow-read` - allow file system read access (can be further restricted to include just the necessary directories)
 - `allow-net` - allow network access (can be further restricted to include just the necessary domains)
+
+Additionally, a tsconfig.json should be specified to support upstream dependencies, which currently need `"allowSyntheticDefaultImports": true` in the typescript compiler options.
+An example is included in this package, which should be accessible at `node_modules/svelte-adapter-deno/tsconfig.deno.json`:
+
+```sh
+$ deno run --allow-env --allow-read --allow-net -c node_modules/svelte-adapter-deno/tsconfig.deno.json build/index.js
+```
+
+It fails the first time it runs, but should work correctly afterwards.
 
 ## Options
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "svelte-adapter-deno",
-	"version": "0.3.1",
+	"version": "0.3.2",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "svelte-adapter-deno",
-			"version": "0.3.1",
+			"version": "0.3.2",
 			"dependencies": {
 				"esbuild": "^0.12.5",
 				"tiny-glob": "^0.2.9"

--- a/package.json
+++ b/package.json
@@ -4,14 +4,14 @@
 		"type": "git",
 		"url": "https://github.com/pluvial/svelte-adapter-deno.git"
 	},
-	"version": "0.3.1",
+	"version": "0.3.2",
 	"type": "module",
 	"exports": {
 		"import": "./index.js"
 	},
 	"main": "index.js",
 	"types": "index.d.ts",
-	"files": ["files", "index.d.ts", "deps.ts"],
+	"files": ["files", "index.d.ts", "deps.ts", "tsconfig.deno.json"],
 	"scripts": {
 		"dev": "rollup -cw",
 		"build": "rollup -c",

--- a/tsconfig.deno.json
+++ b/tsconfig.deno.json
@@ -1,0 +1,5 @@
+{
+  "compilerOptions": {
+    "allowSyntheticDefaultImports": true
+  }
+}


### PR DESCRIPTION
Closes #12

Update documentation to reflect the need for a `tsconfig.json` for upstream dependencies, and add example file to package.