### PR TITLE
Use Deno.listen and Deno.serveHttp instead of oak

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules
 /files
 coverage/
 .env
+.npmrc

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 node_modules
 /files
 coverage/
+.env

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # svelte-adapter-deno-deploy
 
-[Adapter](https://kit.svelte.dev/docs#adapters) for SvelteKit apps that generates a standalone Deno server / request handler.
+[Adapter](https://kit.svelte.dev/docs#adapters) for SvelteKit apps that generates server for Deno Deploy.
 
 ## Usage
 
@@ -12,11 +12,7 @@ import adapter from 'svelte-adapter-deno-deploy';
 
 export default {
   kit: {
-    adapter: adapter({
-      // default options are shown
-      out: 'build',
-      deps: './deps.ts' // (relative to adapter-deno package)
-    })
+    adapter: adapter()
   }
 };
 ```
@@ -56,9 +52,6 @@ The directory to build the server to. It defaults to `build` — i.e. `deno run 
 ### serverFile
 
 You can provide your own server file and use `build/handler.js` to handle sveltekit requests. if this option not provided, `build/server.js` will be created
-
-### filesPrefix
-The prefix for static and client side files (TODO: better description)
 
 ### precompress
 

--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
-# svelte-adapter-deno
+# svelte-adapter-deno-deploy
 
 [Adapter](https://kit.svelte.dev/docs#adapters) for SvelteKit apps that generates a standalone Deno server / request handler.
 
 ## Usage
 
-Install with `npm i -D svelte-adapter-deno`, then add the adapter to your `svelte.config.js`:
+Install with `npm i -D svelte-adapter-deno-deploy`, then add the adapter to your `svelte.config.js`:
 
 ```js
 // svelte.config.js
-import adapter from 'svelte-adapter-deno';
+import adapter from 'svelte-adapter-deno-deploy';
 
 export default {
   kit: {

--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
-# svelte-adapter-deno
+# svelte-adapter-deno-mini
 
-[Adapter](https://kit.svelte.dev/docs#adapters) for SvelteKit apps that generates a standalone Deno server.
+[Adapter](https://kit.svelte.dev/docs#adapters) for SvelteKit apps that generates a standalone Deno server / request handler.
 
 ## Usage
 
-Install with `npm i -D svelte-adapter-deno`, then add the adapter to your `svelte.config.js`:
+Install with `npm i -D svelte-adapter-deno-mini`, then add the adapter to your `svelte.config.js`:
 
 ```js
 // svelte.config.js
-import adapter from 'svelte-adapter-deno';
+import adapter from 'svelte-adapter-deno-mini';
 
 export default {
   kit: {
@@ -51,7 +51,11 @@ Additionally, `--no-check` can be used if deno complains while typechecking upst
 
 ### out
 
-The directory to build the server to. It defaults to `build` — i.e. `deno run --allow-env --allow-read --allow-net build/index.js` would start the server locally after it has been created.
+The directory to build the server to. It defaults to `build` — i.e. `deno run --allow-env --allow-read --allow-net build/server.js` would start the server locally after it has been created.
+
+### serverFile
+
+You can provide your own server file and use `build/handler.js` to handle sveltekit requests. if this option not provided, `build/server.js` will be created
 
 ### precompress
 
@@ -94,8 +98,8 @@ The default options for this version are as follows:
 
 ```js
 {
-  entryPoints: ['.svelte-kit/deno/index.js'],
-  outfile: 'build/index.js',
+  entryPoints: ['.svelte-kit/deno/handler.js'],
+  outfile: 'build/handler.js',
   bundle: true,
   format: 'esm',
   platform: 'neutral',

--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
-# svelte-adapter-deno-mini
+# svelte-adapter-deno
 
 [Adapter](https://kit.svelte.dev/docs#adapters) for SvelteKit apps that generates a standalone Deno server / request handler.
 
 ## Usage
 
-Install with `npm i -D svelte-adapter-deno-mini`, then add the adapter to your `svelte.config.js`:
+Install with `npm i -D svelte-adapter-deno`, then add the adapter to your `svelte.config.js`:
 
 ```js
 // svelte.config.js
-import adapter from 'svelte-adapter-deno-mini';
+import adapter from 'svelte-adapter-deno';
 
 export default {
   kit: {
@@ -30,10 +30,10 @@ deno run --allow-env --allow-read --allow-net build/server.js
 # with a custom build directory
 deno run --allow-env --allow-read --allow-net path/to/build/server.js
 ```
-You should edit server file to change path and hostname
 
 The server needs at least the following permissions to run:
 
+-- `allow-env` - allow environment access, to support runtime configuration via runtime variables (can be further restricted to include just the necessary variables)
 - `allow-read` - allow file system read access (can be further restricted to include just the necessary directories)
 - `allow-net` - allow network access (can be further restricted to include just the necessary domains)
 
@@ -56,6 +56,9 @@ The directory to build the server to. It defaults to `build` — i.e. `deno run 
 ### serverFile
 
 You can provide your own server file and use `build/handler.js` to handle sveltekit requests. if this option not provided, `build/server.js` will be created
+
+### filesPrefix
+The prefix for static and client side files (TODO: better description)
 
 ### precompress
 
@@ -101,6 +104,8 @@ The default options for this version are as follows:
   entryPoints: ['.svelte-kit/deno/handler.js'],
   outfile: 'build/handler.js',
   bundle: true,
+  serverFile: undefined,
+  filesPrefix: './',
   format: 'esm',
   platform: 'neutral',
   sourcemap: 'external'

--- a/README.md
+++ b/README.md
@@ -27,6 +27,50 @@ deno run --allow-env --allow-read --allow-net build/server.js
 deno run --allow-env --allow-read --allow-net path/to/build/server.js
 ```
 
+You can use this github action to automatically deploy your app in deno deploy
+
+.github/workflows/deploy.yml
+```yml
+
+name: Deploy
+
+on: [push]
+
+jobs:
+  deploy: 
+    name: deploy
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read 
+      
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v2
+
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 16
+      - name: Running npm install
+        run: npm install
+
+      - name: Build site
+        run: npm run build
+
+      - name: Remove node_modules
+        run: rm -rf node_modules
+
+      - name: Deploy to Deno Deploy
+        uses: denoland/deployctl@v1
+        with:
+          project: <YOUR PROJECT NAME>
+          entrypoint: "{out}/server.js" # same as `out` option in config
+          root: "{out}"
+
+
+```
+
+
 The server needs at least the following permissions to run:
 
 -- `allow-env` - allow environment access, to support runtime configuration via runtime variables (can be further restricted to include just the necessary variables)

--- a/README.md
+++ b/README.md
@@ -25,15 +25,15 @@ After building the server (`npm run build`), use the following command to start:
 
 ```sh
 # with the default build directory
-deno run --allow-env --allow-read --allow-net build/index.js
+deno run --allow-env --allow-read --allow-net build/server.js
 
 # with a custom build directory
-deno run --allow-env --allow-read --allow-net path/to/build/index.js
+deno run --allow-env --allow-read --allow-net path/to/build/server.js
 ```
+You should edit server file to change path and hostname
 
 The server needs at least the following permissions to run:
 
-- `allow-env` - allow environment access, to support runtime configuration via runtime variables (can be further restricted to include just the necessary variables)
 - `allow-read` - allow file system read access (can be further restricted to include just the necessary directories)
 - `allow-net` - allow network access (can be further restricted to include just the necessary domains)
 
@@ -51,7 +51,7 @@ Additionally, `--no-check` can be used if deno complains while typechecking upst
 
 ### out
 
-The directory to build the server to. It defaults to `build` — i.e. `deno run --allow-env --allow-read --allow-net build/server.js` would start the server locally after it has been created.
+The directory to build the server to. It defaults to `build` — i.e. `deno run --allow-read --allow-net build/server.js` would start the server locally after it has been created.
 
 ### serverFile
 

--- a/deps.ts
+++ b/deps.ts
@@ -3,3 +3,4 @@ export {
 	readerFromStreamReader
 } from 'https://deno.land/std@0.121.0/streams/conversion.ts';
 export { dirname, extname, fromFileUrl, join } from 'https://deno.land/std@0.119.0/path/mod.ts';
+export { serveFile } from 'https://deno.land/std@0.125.0/http/file_server.ts';

--- a/deps.ts
+++ b/deps.ts
@@ -3,5 +3,3 @@ export {
 	readerFromStreamReader
 } from 'https://deno.land/std@0.121.0/streams/conversion.ts';
 export { dirname, extname, fromFileUrl, join } from 'https://deno.land/std@0.119.0/path/mod.ts';
-export { Application } from 'https://deno.land/x/oak/mod.ts';
-export { serveFile } from 'https://deno.land/std@0.121.0/http/file_server.ts';

--- a/deps.ts
+++ b/deps.ts
@@ -4,3 +4,4 @@ export {
 } from 'https://deno.land/std@0.121.0/streams/conversion.ts';
 export { dirname, extname, fromFileUrl, join } from 'https://deno.land/std@0.119.0/path/mod.ts';
 export { Application } from 'https://deno.land/x/oak/mod.ts';
+export { serveFile } from 'https://deno.land/std@0.121.0/http/file_server.ts';

--- a/index.d.ts
+++ b/index.d.ts
@@ -4,6 +4,7 @@ import { BuildOptions } from 'esbuild';
 interface AdapterOptions {
 	out?: string;
 	precompress?: boolean;
+	serverFile?: string,
 	env?: {
 		path?: string;
 		host?: string;

--- a/index.d.ts
+++ b/index.d.ts
@@ -5,6 +5,7 @@ interface AdapterOptions {
 	out?: string;
 	precompress?: boolean;
 	serverFile?: string,
+	filesPrefix?: string,
 	env?: {
 		path?: string;
 		host?: string;

--- a/index.d.ts
+++ b/index.d.ts
@@ -5,7 +5,6 @@ interface AdapterOptions {
 	out?: string;
 	precompress?: boolean;
 	serverFile?: string,
-	filesPrefix?: string,
 	env?: {
 		path?: string;
 		host?: string;

--- a/index.js
+++ b/index.js
@@ -54,7 +54,7 @@ export default function ({
 
 			builder.log.minor('Building server');
 
-			builder.copy(`${files}/index.js`, `${tmp}/index.js`, {
+			builder.copy(`${files}/handler.js`, `${tmp}/handler.js`, {
 				replace: {
 					APP: './server/app.js',
 					MANIFEST: './manifest.js',
@@ -72,7 +72,7 @@ export default function ({
 
 			/** @type {BuildOptions} */
 			const defaultOptions = {
-				entryPoints: [`${tmp}/index.js`],
+				entryPoints: [`${tmp}/handler.js`],
 				outfile: `${out}/handler.js`,
 				bundle: true,
 				// external: Object.keys(JSON.parse(readFileSync('package.json', 'utf8')).dependencies || {}),

--- a/index.js
+++ b/index.js
@@ -19,7 +19,6 @@ export default function ({
 	out = 'build',
 	precompress,
 	serverFile,
-	filesPrefix = '/src/build/',
 	env: { path: path_env = 'SOCKET_PATH', host: host_env = 'HOST', port: port_env = 'PORT' } = {},
 	esbuild: esbuildConfig,
 	deps = fileURLToPath(new URL('./deps.ts', import.meta.url))
@@ -59,7 +58,7 @@ export default function ({
 				replace: {
 					APP: './server/app.js',
 					MANIFEST: './manifest.js',
-					FILES_PREFIX: filesPrefix
+					FILES_PREFIX: `./${out}`
 				}
 			});
 

--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ export default function ({
 	out = 'build',
 	precompress,
 	serverFile,
-	filesPrefix = './',
+	filesPrefix = '/src/build/',
 	env: { path: path_env = 'SOCKET_PATH', host: host_env = 'HOST', port: port_env = 'PORT' } = {},
 	esbuild: esbuildConfig,
 	deps = fileURLToPath(new URL('./deps.ts', import.meta.url))

--- a/index.js
+++ b/index.js
@@ -19,6 +19,7 @@ export default function ({
 	out = 'build',
 	precompress,
 	serverFile,
+	filesPrefix = './',
 	env: { path: path_env = 'SOCKET_PATH', host: host_env = 'HOST', port: port_env = 'PORT' } = {},
 	esbuild: esbuildConfig,
 	deps = fileURLToPath(new URL('./deps.ts', import.meta.url))
@@ -57,7 +58,8 @@ export default function ({
 			builder.copy(`${files}/handler.js`, `${tmp}/handler.js`, {
 				replace: {
 					APP: './server/app.js',
-					MANIFEST: './manifest.js'
+					MANIFEST: './manifest.js',
+					FILES_PREFIX: filesPrefix
 				}
 			});
 
@@ -77,7 +79,7 @@ export default function ({
 				platform: 'browser',
 				// platform: 'neutral',
 				// inject: [join(dirs.files, 'shims.js')],
-				// sourcemap: 'external'
+				sourcemap: 'external'
 			};
 			const buildOptions = esbuildConfig ? await esbuildConfig(defaultOptions) : defaultOptions;
 			await esbuild.build(buildOptions);

--- a/index.js
+++ b/index.js
@@ -18,6 +18,7 @@ const files = fileURLToPath(new URL('./files', import.meta.url));
 export default function ({
 	out = 'build',
 	precompress,
+	serverFile,
 	env: { path: path_env = 'SOCKET_PATH', host: host_env = 'HOST', port: port_env = 'PORT' } = {},
 	esbuild: esbuildConfig,
 	deps = fileURLToPath(new URL('./deps.ts', import.meta.url))
@@ -63,15 +64,21 @@ export default function ({
 				}
 			});
 
+			if(!serverFile) {
+				builder.copy(`${files}/server.js`, `${out}/server.js`)
+			} else {
+				builder.log(`${out}/handler exports default handler which accepts Request and returns Response`)
+			}
+
 			/** @type {BuildOptions} */
 			const defaultOptions = {
 				entryPoints: [`${tmp}/index.js`],
-				outfile: `${out}/index.js`,
+				outfile: `${out}/handler.js`,
 				bundle: true,
 				// external: Object.keys(JSON.parse(readFileSync('package.json', 'utf8')).dependencies || {}),
 				format: 'esm',
-				// platform: 'browser'
-				platform: 'neutral',
+				platform: 'browser',
+				// platform: 'neutral',
 				// inject: [join(dirs.files, 'shims.js')],
 				sourcemap: 'external'
 			};

--- a/index.js
+++ b/index.js
@@ -57,17 +57,14 @@ export default function ({
 			builder.copy(`${files}/handler.js`, `${tmp}/handler.js`, {
 				replace: {
 					APP: './server/app.js',
-					MANIFEST: './manifest.js',
-					PATH_ENV: JSON.stringify(path_env),
-					HOST_ENV: JSON.stringify(host_env),
-					PORT_ENV: JSON.stringify(port_env)
+					MANIFEST: './manifest.js'
 				}
 			});
 
 			if(!serverFile) {
 				builder.copy(`${files}/server.js`, `${out}/server.js`)
 			} else {
-				builder.log(`${out}/handler exports default handler which accepts Request and returns Response`)
+				builder.log(`${out}/handler.js exports default handler which accepts Request and returns Promise<Response>`)
 			}
 
 			/** @type {BuildOptions} */
@@ -80,7 +77,7 @@ export default function ({
 				platform: 'browser',
 				// platform: 'neutral',
 				// inject: [join(dirs.files, 'shims.js')],
-				sourcemap: 'external'
+				// sourcemap: 'external'
 			};
 			const buildOptions = esbuildConfig ? await esbuildConfig(defaultOptions) : defaultOptions;
 			await esbuild.build(buildOptions);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,1853 @@
+{
+	"name": "svelte-adapter-deno",
+	"version": "0.5.0",
+	"lockfileVersion": 2,
+	"requires": true,
+	"packages": {
+		"": {
+			"name": "svelte-adapter-deno",
+			"version": "0.5.0",
+			"dependencies": {
+				"esbuild": "^0.14.10",
+				"tiny-glob": "^0.2.9"
+			},
+			"devDependencies": {
+				"@rollup/plugin-commonjs": "^21.0.1",
+				"@rollup/plugin-json": "^4.1.0",
+				"@rollup/plugin-node-resolve": "^13.1.2",
+				"@sveltejs/kit": "^1.0.0-next.216",
+				"rollup": "^2.63.0",
+				"typescript": "^4.5.4"
+			}
+		},
+		"node_modules/@rollup/plugin-commonjs": {
+			"version": "21.0.1",
+			"resolved": "https://registry.npmjs.org/@rollup/plugin-commonjs/-/plugin-commonjs-21.0.1.tgz",
+			"integrity": "sha512-EA+g22lbNJ8p5kuZJUYyhhDK7WgJckW5g4pNN7n4mAFUM96VuwUnNT3xr2Db2iCZPI1pJPbGyfT5mS9T1dHfMg==",
+			"dev": true,
+			"dependencies": {
+				"@rollup/pluginutils": "^3.1.0",
+				"commondir": "^1.0.1",
+				"estree-walker": "^2.0.1",
+				"glob": "^7.1.6",
+				"is-reference": "^1.2.1",
+				"magic-string": "^0.25.7",
+				"resolve": "^1.17.0"
+			},
+			"engines": {
+				"node": ">= 8.0.0"
+			},
+			"peerDependencies": {
+				"rollup": "^2.38.3"
+			}
+		},
+		"node_modules/@rollup/plugin-json": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/@rollup/plugin-json/-/plugin-json-4.1.0.tgz",
+			"integrity": "sha512-yfLbTdNS6amI/2OpmbiBoW12vngr5NW2jCJVZSBEz+H5KfUJZ2M7sDjk0U6GOOdCWFVScShte29o9NezJ53TPw==",
+			"dev": true,
+			"dependencies": {
+				"@rollup/pluginutils": "^3.0.8"
+			},
+			"peerDependencies": {
+				"rollup": "^1.20.0 || ^2.0.0"
+			}
+		},
+		"node_modules/@rollup/plugin-node-resolve": {
+			"version": "13.1.3",
+			"resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-13.1.3.tgz",
+			"integrity": "sha512-BdxNk+LtmElRo5d06MGY4zoepyrXX1tkzX2hrnPEZ53k78GuOMWLqmJDGIIOPwVRIFZrLQOo+Yr6KtCuLIA0AQ==",
+			"dev": true,
+			"dependencies": {
+				"@rollup/pluginutils": "^3.1.0",
+				"@types/resolve": "1.17.1",
+				"builtin-modules": "^3.1.0",
+				"deepmerge": "^4.2.2",
+				"is-module": "^1.0.0",
+				"resolve": "^1.19.0"
+			},
+			"engines": {
+				"node": ">= 10.0.0"
+			},
+			"peerDependencies": {
+				"rollup": "^2.42.0"
+			}
+		},
+		"node_modules/@rollup/pluginutils": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-3.1.0.tgz",
+			"integrity": "sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==",
+			"dev": true,
+			"dependencies": {
+				"@types/estree": "0.0.39",
+				"estree-walker": "^1.0.1",
+				"picomatch": "^2.2.2"
+			},
+			"engines": {
+				"node": ">= 8.0.0"
+			},
+			"peerDependencies": {
+				"rollup": "^1.20.0||^2.0.0"
+			}
+		},
+		"node_modules/@rollup/pluginutils/node_modules/estree-walker": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-1.0.1.tgz",
+			"integrity": "sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg==",
+			"dev": true
+		},
+		"node_modules/@sveltejs/kit": {
+			"version": "1.0.0-next.239",
+			"resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-1.0.0-next.239.tgz",
+			"integrity": "sha512-+qmiYVdNMmdnjni6/T4sj6yCUf02KvTLpnPZ5yca2grAgMuQkA/sW5Gnce9Zsop0sRKRvM1GY9Pnp8NhERXC6Q==",
+			"dev": true,
+			"dependencies": {
+				"@sveltejs/vite-plugin-svelte": "^1.0.0-next.32",
+				"sade": "^1.7.4",
+				"vite": "^2.7.2"
+			},
+			"bin": {
+				"svelte-kit": "svelte-kit.js"
+			},
+			"engines": {
+				"node": ">=14.13"
+			},
+			"peerDependencies": {
+				"svelte": "^3.44.0"
+			}
+		},
+		"node_modules/@sveltejs/vite-plugin-svelte": {
+			"version": "1.0.0-next.35",
+			"resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte/-/vite-plugin-svelte-1.0.0-next.35.tgz",
+			"integrity": "sha512-PuhI+1L6xqn5gc6jiK4mHmeS8kf3c1E+IaAsJclHbZTNiPQdC5SiTM3cV0FAA4zhwHmXV6pjt8rRHRx8ouFv3g==",
+			"dev": true,
+			"dependencies": {
+				"@rollup/pluginutils": "^4.1.2",
+				"debug": "^4.3.3",
+				"kleur": "^4.1.4",
+				"magic-string": "^0.25.7",
+				"svelte-hmr": "^0.14.9"
+			},
+			"engines": {
+				"node": "^14.13.1 || >= 16"
+			},
+			"peerDependencies": {
+				"diff-match-patch": "^1.0.5",
+				"svelte": "^3.44.0",
+				"vite": "^2.7.0"
+			},
+			"peerDependenciesMeta": {
+				"diff-match-patch": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@sveltejs/vite-plugin-svelte/node_modules/@rollup/pluginutils": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-4.1.2.tgz",
+			"integrity": "sha512-ROn4qvkxP9SyPeHaf7uQC/GPFY6L/OWy9+bd9AwcjOAWQwxRscoEyAUD8qCY5o5iL4jqQwoLk2kaTKJPb/HwzQ==",
+			"dev": true,
+			"dependencies": {
+				"estree-walker": "^2.0.1",
+				"picomatch": "^2.2.2"
+			},
+			"engines": {
+				"node": ">= 8.0.0"
+			}
+		},
+		"node_modules/@types/estree": {
+			"version": "0.0.39",
+			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
+			"integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
+			"dev": true
+		},
+		"node_modules/@types/node": {
+			"version": "17.0.10",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.10.tgz",
+			"integrity": "sha512-S/3xB4KzyFxYGCppyDt68yzBU9ysL88lSdIah4D6cptdcltc4NCPCAMc0+PCpg/lLIyC7IPvj2Z52OJWeIUkog==",
+			"dev": true
+		},
+		"node_modules/@types/resolve": {
+			"version": "1.17.1",
+			"resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.17.1.tgz",
+			"integrity": "sha512-yy7HuzQhj0dhGpD8RLXSZWEkLsV9ibvxvi6EiJ3bkqLAO1RGo0WbkWQiwpRlSFymTJRz0d3k5LM3kkx8ArDbLw==",
+			"dev": true,
+			"dependencies": {
+				"@types/node": "*"
+			}
+		},
+		"node_modules/balanced-match": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+			"dev": true
+		},
+		"node_modules/brace-expansion": {
+			"version": "1.1.11",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+			"dev": true,
+			"dependencies": {
+				"balanced-match": "^1.0.0",
+				"concat-map": "0.0.1"
+			}
+		},
+		"node_modules/builtin-modules": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.2.0.tgz",
+			"integrity": "sha512-lGzLKcioL90C7wMczpkY0n/oART3MbBa8R9OFGE1rJxoVI86u4WAGfEk8Wjv10eKSyTHVGkSo3bvBylCEtk7LA==",
+			"dev": true,
+			"engines": {
+				"node": ">=6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/commondir": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
+			"integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
+			"dev": true
+		},
+		"node_modules/concat-map": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+			"dev": true
+		},
+		"node_modules/debug": {
+			"version": "4.3.3",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
+			"integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
+			"dev": true,
+			"dependencies": {
+				"ms": "2.1.2"
+			},
+			"engines": {
+				"node": ">=6.0"
+			},
+			"peerDependenciesMeta": {
+				"supports-color": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/deepmerge": {
+			"version": "4.2.2",
+			"resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
+			"integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==",
+			"dev": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/esbuild": {
+			"version": "0.14.12",
+			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.14.12.tgz",
+			"integrity": "sha512-o1vQkG+eSDLkWDqWfR8v6eI+byGAUkbRs30eAJcJxUFp3dwMGWR0tAjtam1Bb1RSS2j+4kAUFiuJTnW3J4CYcw==",
+			"hasInstallScript": true,
+			"bin": {
+				"esbuild": "bin/esbuild"
+			},
+			"optionalDependencies": {
+				"esbuild-android-arm64": "0.14.12",
+				"esbuild-darwin-64": "0.14.12",
+				"esbuild-darwin-arm64": "0.14.12",
+				"esbuild-freebsd-64": "0.14.12",
+				"esbuild-freebsd-arm64": "0.14.12",
+				"esbuild-linux-32": "0.14.12",
+				"esbuild-linux-64": "0.14.12",
+				"esbuild-linux-arm": "0.14.12",
+				"esbuild-linux-arm64": "0.14.12",
+				"esbuild-linux-mips64le": "0.14.12",
+				"esbuild-linux-ppc64le": "0.14.12",
+				"esbuild-linux-s390x": "0.14.12",
+				"esbuild-netbsd-64": "0.14.12",
+				"esbuild-openbsd-64": "0.14.12",
+				"esbuild-sunos-64": "0.14.12",
+				"esbuild-windows-32": "0.14.12",
+				"esbuild-windows-64": "0.14.12",
+				"esbuild-windows-arm64": "0.14.12"
+			}
+		},
+		"node_modules/esbuild-android-arm64": {
+			"version": "0.14.12",
+			"resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.14.12.tgz",
+			"integrity": "sha512-eO4JHwnTeJq1/xC9K0FdHNEYztwT0HaWHnOzR5kXKwJxHatxDNZ+lCHOSxMzh9uVSmnA8YwdSiXPWbwTlWZVrw==",
+			"cpu": [
+				"arm64"
+			],
+			"optional": true,
+			"os": [
+				"android"
+			]
+		},
+		"node_modules/esbuild-darwin-64": {
+			"version": "0.14.12",
+			"resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.14.12.tgz",
+			"integrity": "sha512-LyZ81assnJWhq2IxKEVipwddKlXLTubbz/IObyKOm5cWS9jQCpuwQey2PpzroWSiy7QLGV8XCGWY5b8U8fsmWA==",
+			"cpu": [
+				"x64"
+			],
+			"optional": true,
+			"os": [
+				"darwin"
+			]
+		},
+		"node_modules/esbuild-darwin-arm64": {
+			"version": "0.14.12",
+			"resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.14.12.tgz",
+			"integrity": "sha512-jj27iSbDS4KlftN1PHHNiTrtXPQIk11J/qpQiQLwKJpeEMNeJUBfQlS7X7dXgFFMxV0rNtcRl8AimEFl+qEMRQ==",
+			"cpu": [
+				"arm64"
+			],
+			"optional": true,
+			"os": [
+				"darwin"
+			]
+		},
+		"node_modules/esbuild-freebsd-64": {
+			"version": "0.14.12",
+			"resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.14.12.tgz",
+			"integrity": "sha512-RnTty09bA8Ts/eWnrJsYiE2dFM6ZseKYQ/7QCM5QYphU6GbifooO9oGjc/UE3Sg8R58yZVO15vnIV0i+kTgDOw==",
+			"cpu": [
+				"x64"
+			],
+			"optional": true,
+			"os": [
+				"freebsd"
+			]
+		},
+		"node_modules/esbuild-freebsd-arm64": {
+			"version": "0.14.12",
+			"resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.14.12.tgz",
+			"integrity": "sha512-AvAQoEgsHE53hucgoVWdHnXJBl0r9W/7eUCaBvpcgYu3W/EbPZ26VnZwfSXLpk0Pf3t7o6SRwrU+KDTKPscDTw==",
+			"cpu": [
+				"arm64"
+			],
+			"optional": true,
+			"os": [
+				"freebsd"
+			]
+		},
+		"node_modules/esbuild-linux-32": {
+			"version": "0.14.12",
+			"resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.14.12.tgz",
+			"integrity": "sha512-na4I5i2c9ACPuglfYmrnJ6qGQnFJb59dFjyFk5OHTCtoKCq3lXbGHrvYa+3sYlOrRax1kYuRDRGse7YsDLbr3Q==",
+			"cpu": [
+				"ia32"
+			],
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/esbuild-linux-64": {
+			"version": "0.14.12",
+			"resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.14.12.tgz",
+			"integrity": "sha512-ObPoYGakJLx/RldQsFQiwsQ7N9YbQ4LLazHtpKx34bjqFjhqO5JiHPVAJYCmAtci3cJMsZ5DtEFXvijytTBz1g==",
+			"cpu": [
+				"x64"
+			],
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/esbuild-linux-arm": {
+			"version": "0.14.12",
+			"resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.14.12.tgz",
+			"integrity": "sha512-tD4q/zVUeYkThGehYAJQElo80+ysxvq5vpd2QvykDp4hvIidEUJu2hf+NzG5OuMJSQJmAeAWPrkFOXN+6di9cA==",
+			"cpu": [
+				"arm"
+			],
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/esbuild-linux-arm64": {
+			"version": "0.14.12",
+			"resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.14.12.tgz",
+			"integrity": "sha512-i1/ikCl9gG9yx6QuI+8yJMk9XHUu8ekIQOo6cex2pDqXY5KVHSXDTAT4FDWOd5YXQ1QTjneBAQHcKGft4pd6PQ==",
+			"cpu": [
+				"arm64"
+			],
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/esbuild-linux-mips64le": {
+			"version": "0.14.12",
+			"resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.14.12.tgz",
+			"integrity": "sha512-+/a6/tiKUCENep8ryUR75Jba4znG51Sb75OzKT6phZFEkB7fao4+GZD39Zxx3EaaA5OC10MsJPjJMFrn0dMusg==",
+			"cpu": [
+				"mips64el"
+			],
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/esbuild-linux-ppc64le": {
+			"version": "0.14.12",
+			"resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.14.12.tgz",
+			"integrity": "sha512-SD7e2VLza/cEU2qKuD18Ibt1V0h3TUuerC1Mp3jRJ4RRGXWAyUt4gUpqKSiB7R0rHe6LWECdLbeVFAuGEntCeA==",
+			"cpu": [
+				"ppc64"
+			],
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/esbuild-linux-s390x": {
+			"version": "0.14.12",
+			"resolved": "https://registry.npmjs.org/esbuild-linux-s390x/-/esbuild-linux-s390x-0.14.12.tgz",
+			"integrity": "sha512-KZmjYgAvYUpPBG0v6xv8qCngbfcRKC2AdYx3H3j3VqJfICgjt5XYsyG7ntWdc8Rdw9jZxr9sni6othy2Rp/T+A==",
+			"cpu": [
+				"s390x"
+			],
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/esbuild-netbsd-64": {
+			"version": "0.14.12",
+			"resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.14.12.tgz",
+			"integrity": "sha512-dG+hbCIJC65fHqzkTEYbrPSYG3m8pEaI9A1VDtqHfV13Oiw9/tua1odd47iwoWvTyurErb49wanHsIAKb8/2oQ==",
+			"cpu": [
+				"x64"
+			],
+			"optional": true,
+			"os": [
+				"netbsd"
+			]
+		},
+		"node_modules/esbuild-openbsd-64": {
+			"version": "0.14.12",
+			"resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.14.12.tgz",
+			"integrity": "sha512-W3SwxnMjJR3HtBD0aij5WPd0ow2bRB5BsW6FjhN7FgwDBQ+jgniFs1dq54HOkjQ2qBJrt8JvPDFAxacWjdD6Jw==",
+			"cpu": [
+				"x64"
+			],
+			"optional": true,
+			"os": [
+				"openbsd"
+			]
+		},
+		"node_modules/esbuild-sunos-64": {
+			"version": "0.14.12",
+			"resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.14.12.tgz",
+			"integrity": "sha512-jU/IcTFwvUtt21wOmqKJrevyHQ5XRfiCdFbPie4wsYr8VFcPZZsz18A9lcoI8gZdrF/8pBdD0V+L2UuUY0KsGg==",
+			"cpu": [
+				"x64"
+			],
+			"optional": true,
+			"os": [
+				"sunos"
+			]
+		},
+		"node_modules/esbuild-windows-32": {
+			"version": "0.14.12",
+			"resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.14.12.tgz",
+			"integrity": "sha512-6luae9cmTB0rSPMCQFWMgf0SLNZ9hxusoS0poVEUHJf3n8bW6wgdyLE2xfYcEcXPMsjAt2e71/etkpqlFxeuYg==",
+			"cpu": [
+				"ia32"
+			],
+			"optional": true,
+			"os": [
+				"win32"
+			]
+		},
+		"node_modules/esbuild-windows-64": {
+			"version": "0.14.12",
+			"resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.14.12.tgz",
+			"integrity": "sha512-CdCXvME/7s0uMt+4rYd8d5roHJJ5k2VDOzWaOMWExjroet+nSSZngfLpxI5St+28lXLeBorUxeBS+p1qcfEDfw==",
+			"cpu": [
+				"x64"
+			],
+			"optional": true,
+			"os": [
+				"win32"
+			]
+		},
+		"node_modules/esbuild-windows-arm64": {
+			"version": "0.14.12",
+			"resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.14.12.tgz",
+			"integrity": "sha512-vNuLQh/MpYDepK0GNpEWHy0Kn7Jf3Shz/Xetf8hUIc31jgCR1qbLVLDf3ckQdanD2U430YZupOGtEZKRwno79w==",
+			"cpu": [
+				"arm64"
+			],
+			"optional": true,
+			"os": [
+				"win32"
+			]
+		},
+		"node_modules/estree-walker": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+			"integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+			"dev": true
+		},
+		"node_modules/fs.realpath": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+			"dev": true
+		},
+		"node_modules/fsevents": {
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+			"integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+			"dev": true,
+			"hasInstallScript": true,
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+			}
+		},
+		"node_modules/function-bind": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+			"integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+			"dev": true
+		},
+		"node_modules/glob": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
+			"integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
+			"dev": true,
+			"dependencies": {
+				"fs.realpath": "^1.0.0",
+				"inflight": "^1.0.4",
+				"inherits": "2",
+				"minimatch": "^3.0.4",
+				"once": "^1.3.0",
+				"path-is-absolute": "^1.0.0"
+			},
+			"engines": {
+				"node": "*"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/globalyzer": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/globalyzer/-/globalyzer-0.1.0.tgz",
+			"integrity": "sha512-40oNTM9UfG6aBmuKxk/giHn5nQ8RVz/SS4Ir6zgzOv9/qC3kKZ9v4etGTcJbEl/NyVQH7FGU7d+X1egr57Md2Q=="
+		},
+		"node_modules/globrex": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/globrex/-/globrex-0.1.2.tgz",
+			"integrity": "sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg=="
+		},
+		"node_modules/has": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+			"integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+			"dev": true,
+			"dependencies": {
+				"function-bind": "^1.1.1"
+			},
+			"engines": {
+				"node": ">= 0.4.0"
+			}
+		},
+		"node_modules/inflight": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+			"dev": true,
+			"dependencies": {
+				"once": "^1.3.0",
+				"wrappy": "1"
+			}
+		},
+		"node_modules/inherits": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+			"dev": true
+		},
+		"node_modules/is-core-module": {
+			"version": "2.8.1",
+			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.8.1.tgz",
+			"integrity": "sha512-SdNCUs284hr40hFTFP6l0IfZ/RSrMXF3qgoRHd3/79unUTvrFO/JoXwkGm+5J/Oe3E/b5GsnG330uUNgRpu1PA==",
+			"dev": true,
+			"dependencies": {
+				"has": "^1.0.3"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/is-module": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-module/-/is-module-1.0.0.tgz",
+			"integrity": "sha1-Mlj7afeMFNW4FdZkM2tM/7ZEFZE=",
+			"dev": true
+		},
+		"node_modules/is-reference": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/is-reference/-/is-reference-1.2.1.tgz",
+			"integrity": "sha512-U82MsXXiFIrjCK4otLT+o2NA2Cd2g5MLoOVXUZjIOhLurrRxpEXzI8O0KZHr3IjLvlAH1kTPYSuqer5T9ZVBKQ==",
+			"dev": true,
+			"dependencies": {
+				"@types/estree": "*"
+			}
+		},
+		"node_modules/kleur": {
+			"version": "4.1.4",
+			"resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.4.tgz",
+			"integrity": "sha512-8QADVssbrFjivHWQU7KkMgptGTl6WAcSdlbBPY4uNF+mWr6DGcKrvY2w4FQJoXch7+fKMjj0dRrL75vk3k23OA==",
+			"dev": true,
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/magic-string": {
+			"version": "0.25.7",
+			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.7.tgz",
+			"integrity": "sha512-4CrMT5DOHTDk4HYDlzmwu4FVCcIYI8gauveasrdCu2IKIFOJ3f0v/8MDGJCDL9oD2ppz/Av1b0Nj345H9M+XIA==",
+			"dev": true,
+			"dependencies": {
+				"sourcemap-codec": "^1.4.4"
+			}
+		},
+		"node_modules/minimatch": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+			"dev": true,
+			"dependencies": {
+				"brace-expansion": "^1.1.7"
+			},
+			"engines": {
+				"node": "*"
+			}
+		},
+		"node_modules/mri": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
+			"integrity": "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==",
+			"dev": true,
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/ms": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+			"dev": true
+		},
+		"node_modules/nanoid": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.2.0.tgz",
+			"integrity": "sha512-fmsZYa9lpn69Ad5eDn7FMcnnSR+8R34W9qJEijxYhTbfOWzr22n1QxCMzXLK+ODyW2973V3Fux959iQoUxzUIA==",
+			"dev": true,
+			"bin": {
+				"nanoid": "bin/nanoid.cjs"
+			},
+			"engines": {
+				"node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+			}
+		},
+		"node_modules/once": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+			"dev": true,
+			"dependencies": {
+				"wrappy": "1"
+			}
+		},
+		"node_modules/path-is-absolute": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+			"dev": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/path-parse": {
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+			"integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+			"dev": true
+		},
+		"node_modules/picocolors": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
+			"integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
+			"dev": true
+		},
+		"node_modules/picomatch": {
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+			"integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+			"dev": true,
+			"engines": {
+				"node": ">=8.6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/jonschlinkert"
+			}
+		},
+		"node_modules/postcss": {
+			"version": "8.4.5",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.5.tgz",
+			"integrity": "sha512-jBDboWM8qpaqwkMwItqTQTiFikhs/67OYVvblFFTM7MrZjt6yMKd6r2kgXizEbTTljacm4NldIlZnhbjr84QYg==",
+			"dev": true,
+			"dependencies": {
+				"nanoid": "^3.1.30",
+				"picocolors": "^1.0.0",
+				"source-map-js": "^1.0.1"
+			},
+			"engines": {
+				"node": "^10 || ^12 || >=14"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/postcss/"
+			}
+		},
+		"node_modules/resolve": {
+			"version": "1.21.1",
+			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.21.1.tgz",
+			"integrity": "sha512-lfEImVbnolPuaSZuLQ52cAxPBHeI77sPwCOWRdy12UG/CNa8an7oBHH1R+Fp1/mUqSJi4c8TIP6FOIPSZAUrEQ==",
+			"dev": true,
+			"dependencies": {
+				"is-core-module": "^2.8.0",
+				"path-parse": "^1.0.7",
+				"supports-preserve-symlinks-flag": "^1.0.0"
+			},
+			"bin": {
+				"resolve": "bin/resolve"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/rollup": {
+			"version": "2.66.0",
+			"resolved": "https://registry.npmjs.org/rollup/-/rollup-2.66.0.tgz",
+			"integrity": "sha512-L6mKOkdyP8HK5kKJXaiWG7KZDumPJjuo1P+cfyHOJPNNTK3Moe7zCH5+fy7v8pVmHXtlxorzaBjvkBMB23s98g==",
+			"dev": true,
+			"bin": {
+				"rollup": "dist/bin/rollup"
+			},
+			"engines": {
+				"node": ">=10.0.0"
+			},
+			"optionalDependencies": {
+				"fsevents": "~2.3.2"
+			}
+		},
+		"node_modules/sade": {
+			"version": "1.8.1",
+			"resolved": "https://registry.npmjs.org/sade/-/sade-1.8.1.tgz",
+			"integrity": "sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==",
+			"dev": true,
+			"dependencies": {
+				"mri": "^1.1.0"
+			},
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/source-map-js": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
+			"integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
+			"dev": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/sourcemap-codec": {
+			"version": "1.4.8",
+			"resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
+			"integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
+			"dev": true
+		},
+		"node_modules/supports-preserve-symlinks-flag": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+			"integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+			"dev": true,
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/svelte": {
+			"version": "3.46.2",
+			"resolved": "https://registry.npmjs.org/svelte/-/svelte-3.46.2.tgz",
+			"integrity": "sha512-RXSAtYNefe01Sb1lXtZ2I+gzn3t/h/59hoaRNeRrm8IkMIu6BSiAkbpi41xb+C44x54YKnbk9+dtfs3pM4hECA==",
+			"dev": true,
+			"peer": true,
+			"engines": {
+				"node": ">= 8"
+			}
+		},
+		"node_modules/svelte-hmr": {
+			"version": "0.14.9",
+			"resolved": "https://registry.npmjs.org/svelte-hmr/-/svelte-hmr-0.14.9.tgz",
+			"integrity": "sha512-bKE9+4qb4sAnA+TKHiYurUl970rjA0XmlP9TEP7K/ncyWz3m81kA4HOgmlZK/7irGK7gzZlaPDI3cmf8fp/+tg==",
+			"dev": true,
+			"peerDependencies": {
+				"svelte": ">=3.19.0"
+			}
+		},
+		"node_modules/tiny-glob": {
+			"version": "0.2.9",
+			"resolved": "https://registry.npmjs.org/tiny-glob/-/tiny-glob-0.2.9.tgz",
+			"integrity": "sha512-g/55ssRPUjShh+xkfx9UPDXqhckHEsHr4Vd9zX55oSdGZc/MD0m3sferOkwWtp98bv+kcVfEHtRJgBVJzelrzg==",
+			"dependencies": {
+				"globalyzer": "0.1.0",
+				"globrex": "^0.1.2"
+			}
+		},
+		"node_modules/typescript": {
+			"version": "4.5.5",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
+			"integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
+			"dev": true,
+			"bin": {
+				"tsc": "bin/tsc",
+				"tsserver": "bin/tsserver"
+			},
+			"engines": {
+				"node": ">=4.2.0"
+			}
+		},
+		"node_modules/vite": {
+			"version": "2.7.13",
+			"resolved": "https://registry.npmjs.org/vite/-/vite-2.7.13.tgz",
+			"integrity": "sha512-Mq8et7f3aK0SgSxjDNfOAimZGW9XryfHRa/uV0jseQSilg+KhYDSoNb9h1rknOy6SuMkvNDLKCYAYYUMCE+IgQ==",
+			"dev": true,
+			"dependencies": {
+				"esbuild": "^0.13.12",
+				"postcss": "^8.4.5",
+				"resolve": "^1.20.0",
+				"rollup": "^2.59.0"
+			},
+			"bin": {
+				"vite": "bin/vite.js"
+			},
+			"engines": {
+				"node": ">=12.2.0"
+			},
+			"optionalDependencies": {
+				"fsevents": "~2.3.2"
+			},
+			"peerDependencies": {
+				"less": "*",
+				"sass": "*",
+				"stylus": "*"
+			},
+			"peerDependenciesMeta": {
+				"less": {
+					"optional": true
+				},
+				"sass": {
+					"optional": true
+				},
+				"stylus": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/vite/node_modules/esbuild": {
+			"version": "0.13.15",
+			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.13.15.tgz",
+			"integrity": "sha512-raCxt02HBKv8RJxE8vkTSCXGIyKHdEdGfUmiYb8wnabnaEmHzyW7DCHb5tEN0xU8ryqg5xw54mcwnYkC4x3AIw==",
+			"dev": true,
+			"hasInstallScript": true,
+			"bin": {
+				"esbuild": "bin/esbuild"
+			},
+			"optionalDependencies": {
+				"esbuild-android-arm64": "0.13.15",
+				"esbuild-darwin-64": "0.13.15",
+				"esbuild-darwin-arm64": "0.13.15",
+				"esbuild-freebsd-64": "0.13.15",
+				"esbuild-freebsd-arm64": "0.13.15",
+				"esbuild-linux-32": "0.13.15",
+				"esbuild-linux-64": "0.13.15",
+				"esbuild-linux-arm": "0.13.15",
+				"esbuild-linux-arm64": "0.13.15",
+				"esbuild-linux-mips64le": "0.13.15",
+				"esbuild-linux-ppc64le": "0.13.15",
+				"esbuild-netbsd-64": "0.13.15",
+				"esbuild-openbsd-64": "0.13.15",
+				"esbuild-sunos-64": "0.13.15",
+				"esbuild-windows-32": "0.13.15",
+				"esbuild-windows-64": "0.13.15",
+				"esbuild-windows-arm64": "0.13.15"
+			}
+		},
+		"node_modules/vite/node_modules/esbuild-android-arm64": {
+			"version": "0.13.15",
+			"resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.13.15.tgz",
+			"integrity": "sha512-m602nft/XXeO8YQPUDVoHfjyRVPdPgjyyXOxZ44MK/agewFFkPa8tUo6lAzSWh5Ui5PB4KR9UIFTSBKh/RrCmg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"android"
+			]
+		},
+		"node_modules/vite/node_modules/esbuild-darwin-64": {
+			"version": "0.13.15",
+			"resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.13.15.tgz",
+			"integrity": "sha512-ihOQRGs2yyp7t5bArCwnvn2Atr6X4axqPpEdCFPVp7iUj4cVSdisgvEKdNR7yH3JDjW6aQDw40iQFoTqejqxvQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"darwin"
+			]
+		},
+		"node_modules/vite/node_modules/esbuild-darwin-arm64": {
+			"version": "0.13.15",
+			"resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.13.15.tgz",
+			"integrity": "sha512-i1FZssTVxUqNlJ6cBTj5YQj4imWy3m49RZRnHhLpefFIh0To05ow9DTrXROTE1urGTQCloFUXTX8QfGJy1P8dQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"darwin"
+			]
+		},
+		"node_modules/vite/node_modules/esbuild-freebsd-64": {
+			"version": "0.13.15",
+			"resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.13.15.tgz",
+			"integrity": "sha512-G3dLBXUI6lC6Z09/x+WtXBXbOYQZ0E8TDBqvn7aMaOCzryJs8LyVXKY4CPnHFXZAbSwkCbqiPuSQ1+HhrNk7EA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"freebsd"
+			]
+		},
+		"node_modules/vite/node_modules/esbuild-freebsd-arm64": {
+			"version": "0.13.15",
+			"resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.13.15.tgz",
+			"integrity": "sha512-KJx0fzEDf1uhNOZQStV4ujg30WlnwqUASaGSFPhznLM/bbheu9HhqZ6mJJZM32lkyfGJikw0jg7v3S0oAvtvQQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"freebsd"
+			]
+		},
+		"node_modules/vite/node_modules/esbuild-linux-32": {
+			"version": "0.13.15",
+			"resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.13.15.tgz",
+			"integrity": "sha512-ZvTBPk0YWCLMCXiFmD5EUtB30zIPvC5Itxz0mdTu/xZBbbHJftQgLWY49wEPSn2T/TxahYCRDWun5smRa0Tu+g==",
+			"cpu": [
+				"ia32"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/vite/node_modules/esbuild-linux-64": {
+			"version": "0.13.15",
+			"resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.13.15.tgz",
+			"integrity": "sha512-eCKzkNSLywNeQTRBxJRQ0jxRCl2YWdMB3+PkWFo2BBQYC5mISLIVIjThNtn6HUNqua1pnvgP5xX0nHbZbPj5oA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/vite/node_modules/esbuild-linux-arm": {
+			"version": "0.13.15",
+			"resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.13.15.tgz",
+			"integrity": "sha512-wUHttDi/ol0tD8ZgUMDH8Ef7IbDX+/UsWJOXaAyTdkT7Yy9ZBqPg8bgB/Dn3CZ9SBpNieozrPRHm0BGww7W/jA==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/vite/node_modules/esbuild-linux-arm64": {
+			"version": "0.13.15",
+			"resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.13.15.tgz",
+			"integrity": "sha512-bYpuUlN6qYU9slzr/ltyLTR9YTBS7qUDymO8SV7kjeNext61OdmqFAzuVZom+OLW1HPHseBfJ/JfdSlx8oTUoA==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/vite/node_modules/esbuild-linux-mips64le": {
+			"version": "0.13.15",
+			"resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.13.15.tgz",
+			"integrity": "sha512-KlVjIG828uFPyJkO/8gKwy9RbXhCEUeFsCGOJBepUlpa7G8/SeZgncUEz/tOOUJTcWMTmFMtdd3GElGyAtbSWg==",
+			"cpu": [
+				"mips64el"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/vite/node_modules/esbuild-linux-ppc64le": {
+			"version": "0.13.15",
+			"resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.13.15.tgz",
+			"integrity": "sha512-h6gYF+OsaqEuBjeesTBtUPw0bmiDu7eAeuc2OEH9S6mV9/jPhPdhOWzdeshb0BskRZxPhxPOjqZ+/OqLcxQwEQ==",
+			"cpu": [
+				"ppc64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/vite/node_modules/esbuild-netbsd-64": {
+			"version": "0.13.15",
+			"resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.13.15.tgz",
+			"integrity": "sha512-3+yE9emwoevLMyvu+iR3rsa+Xwhie7ZEHMGDQ6dkqP/ndFzRHkobHUKTe+NCApSqG5ce2z4rFu+NX/UHnxlh3w==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"netbsd"
+			]
+		},
+		"node_modules/vite/node_modules/esbuild-openbsd-64": {
+			"version": "0.13.15",
+			"resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.13.15.tgz",
+			"integrity": "sha512-wTfvtwYJYAFL1fSs8yHIdf5GEE4NkbtbXtjLWjM3Cw8mmQKqsg8kTiqJ9NJQe5NX/5Qlo7Xd9r1yKMMkHllp5g==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"openbsd"
+			]
+		},
+		"node_modules/vite/node_modules/esbuild-sunos-64": {
+			"version": "0.13.15",
+			"resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.13.15.tgz",
+			"integrity": "sha512-lbivT9Bx3t1iWWrSnGyBP9ODriEvWDRiweAs69vI+miJoeKwHWOComSRukttbuzjZ8r1q0mQJ8Z7yUsDJ3hKdw==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"sunos"
+			]
+		},
+		"node_modules/vite/node_modules/esbuild-windows-32": {
+			"version": "0.13.15",
+			"resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.13.15.tgz",
+			"integrity": "sha512-fDMEf2g3SsJ599MBr50cY5ve5lP1wyVwTe6aLJsM01KtxyKkB4UT+fc5MXQFn3RLrAIAZOG+tHC+yXObpSn7Nw==",
+			"cpu": [
+				"ia32"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"win32"
+			]
+		},
+		"node_modules/vite/node_modules/esbuild-windows-64": {
+			"version": "0.13.15",
+			"resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.13.15.tgz",
+			"integrity": "sha512-9aMsPRGDWCd3bGjUIKG/ZOJPKsiztlxl/Q3C1XDswO6eNX/Jtwu4M+jb6YDH9hRSUflQWX0XKAfWzgy5Wk54JQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"win32"
+			]
+		},
+		"node_modules/vite/node_modules/esbuild-windows-arm64": {
+			"version": "0.13.15",
+			"resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.13.15.tgz",
+			"integrity": "sha512-zzvyCVVpbwQQATaf3IG8mu1IwGEiDxKkYUdA4FpoCHi1KtPa13jeScYDjlW0Qh+ebWzpKfR2ZwvqAQkSWNcKjA==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"win32"
+			]
+		},
+		"node_modules/wrappy": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+			"dev": true
+		}
+	},
+	"dependencies": {
+		"@rollup/plugin-commonjs": {
+			"version": "21.0.1",
+			"resolved": "https://registry.npmjs.org/@rollup/plugin-commonjs/-/plugin-commonjs-21.0.1.tgz",
+			"integrity": "sha512-EA+g22lbNJ8p5kuZJUYyhhDK7WgJckW5g4pNN7n4mAFUM96VuwUnNT3xr2Db2iCZPI1pJPbGyfT5mS9T1dHfMg==",
+			"dev": true,
+			"requires": {
+				"@rollup/pluginutils": "^3.1.0",
+				"commondir": "^1.0.1",
+				"estree-walker": "^2.0.1",
+				"glob": "^7.1.6",
+				"is-reference": "^1.2.1",
+				"magic-string": "^0.25.7",
+				"resolve": "^1.17.0"
+			}
+		},
+		"@rollup/plugin-json": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/@rollup/plugin-json/-/plugin-json-4.1.0.tgz",
+			"integrity": "sha512-yfLbTdNS6amI/2OpmbiBoW12vngr5NW2jCJVZSBEz+H5KfUJZ2M7sDjk0U6GOOdCWFVScShte29o9NezJ53TPw==",
+			"dev": true,
+			"requires": {
+				"@rollup/pluginutils": "^3.0.8"
+			}
+		},
+		"@rollup/plugin-node-resolve": {
+			"version": "13.1.3",
+			"resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-13.1.3.tgz",
+			"integrity": "sha512-BdxNk+LtmElRo5d06MGY4zoepyrXX1tkzX2hrnPEZ53k78GuOMWLqmJDGIIOPwVRIFZrLQOo+Yr6KtCuLIA0AQ==",
+			"dev": true,
+			"requires": {
+				"@rollup/pluginutils": "^3.1.0",
+				"@types/resolve": "1.17.1",
+				"builtin-modules": "^3.1.0",
+				"deepmerge": "^4.2.2",
+				"is-module": "^1.0.0",
+				"resolve": "^1.19.0"
+			}
+		},
+		"@rollup/pluginutils": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-3.1.0.tgz",
+			"integrity": "sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==",
+			"dev": true,
+			"requires": {
+				"@types/estree": "0.0.39",
+				"estree-walker": "^1.0.1",
+				"picomatch": "^2.2.2"
+			},
+			"dependencies": {
+				"estree-walker": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-1.0.1.tgz",
+					"integrity": "sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg==",
+					"dev": true
+				}
+			}
+		},
+		"@sveltejs/kit": {
+			"version": "1.0.0-next.239",
+			"resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-1.0.0-next.239.tgz",
+			"integrity": "sha512-+qmiYVdNMmdnjni6/T4sj6yCUf02KvTLpnPZ5yca2grAgMuQkA/sW5Gnce9Zsop0sRKRvM1GY9Pnp8NhERXC6Q==",
+			"dev": true,
+			"requires": {
+				"@sveltejs/vite-plugin-svelte": "^1.0.0-next.32",
+				"sade": "^1.7.4",
+				"vite": "^2.7.2"
+			}
+		},
+		"@sveltejs/vite-plugin-svelte": {
+			"version": "1.0.0-next.35",
+			"resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte/-/vite-plugin-svelte-1.0.0-next.35.tgz",
+			"integrity": "sha512-PuhI+1L6xqn5gc6jiK4mHmeS8kf3c1E+IaAsJclHbZTNiPQdC5SiTM3cV0FAA4zhwHmXV6pjt8rRHRx8ouFv3g==",
+			"dev": true,
+			"requires": {
+				"@rollup/pluginutils": "^4.1.2",
+				"debug": "^4.3.3",
+				"kleur": "^4.1.4",
+				"magic-string": "^0.25.7",
+				"svelte-hmr": "^0.14.9"
+			},
+			"dependencies": {
+				"@rollup/pluginutils": {
+					"version": "4.1.2",
+					"resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-4.1.2.tgz",
+					"integrity": "sha512-ROn4qvkxP9SyPeHaf7uQC/GPFY6L/OWy9+bd9AwcjOAWQwxRscoEyAUD8qCY5o5iL4jqQwoLk2kaTKJPb/HwzQ==",
+					"dev": true,
+					"requires": {
+						"estree-walker": "^2.0.1",
+						"picomatch": "^2.2.2"
+					}
+				}
+			}
+		},
+		"@types/estree": {
+			"version": "0.0.39",
+			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
+			"integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
+			"dev": true
+		},
+		"@types/node": {
+			"version": "17.0.10",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.10.tgz",
+			"integrity": "sha512-S/3xB4KzyFxYGCppyDt68yzBU9ysL88lSdIah4D6cptdcltc4NCPCAMc0+PCpg/lLIyC7IPvj2Z52OJWeIUkog==",
+			"dev": true
+		},
+		"@types/resolve": {
+			"version": "1.17.1",
+			"resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.17.1.tgz",
+			"integrity": "sha512-yy7HuzQhj0dhGpD8RLXSZWEkLsV9ibvxvi6EiJ3bkqLAO1RGo0WbkWQiwpRlSFymTJRz0d3k5LM3kkx8ArDbLw==",
+			"dev": true,
+			"requires": {
+				"@types/node": "*"
+			}
+		},
+		"balanced-match": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+			"dev": true
+		},
+		"brace-expansion": {
+			"version": "1.1.11",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+			"dev": true,
+			"requires": {
+				"balanced-match": "^1.0.0",
+				"concat-map": "0.0.1"
+			}
+		},
+		"builtin-modules": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.2.0.tgz",
+			"integrity": "sha512-lGzLKcioL90C7wMczpkY0n/oART3MbBa8R9OFGE1rJxoVI86u4WAGfEk8Wjv10eKSyTHVGkSo3bvBylCEtk7LA==",
+			"dev": true
+		},
+		"commondir": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
+			"integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
+			"dev": true
+		},
+		"concat-map": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+			"dev": true
+		},
+		"debug": {
+			"version": "4.3.3",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
+			"integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
+			"dev": true,
+			"requires": {
+				"ms": "2.1.2"
+			}
+		},
+		"deepmerge": {
+			"version": "4.2.2",
+			"resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
+			"integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==",
+			"dev": true
+		},
+		"esbuild": {
+			"version": "0.14.12",
+			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.14.12.tgz",
+			"integrity": "sha512-o1vQkG+eSDLkWDqWfR8v6eI+byGAUkbRs30eAJcJxUFp3dwMGWR0tAjtam1Bb1RSS2j+4kAUFiuJTnW3J4CYcw==",
+			"requires": {
+				"esbuild-android-arm64": "0.14.12",
+				"esbuild-darwin-64": "0.14.12",
+				"esbuild-darwin-arm64": "0.14.12",
+				"esbuild-freebsd-64": "0.14.12",
+				"esbuild-freebsd-arm64": "0.14.12",
+				"esbuild-linux-32": "0.14.12",
+				"esbuild-linux-64": "0.14.12",
+				"esbuild-linux-arm": "0.14.12",
+				"esbuild-linux-arm64": "0.14.12",
+				"esbuild-linux-mips64le": "0.14.12",
+				"esbuild-linux-ppc64le": "0.14.12",
+				"esbuild-linux-s390x": "0.14.12",
+				"esbuild-netbsd-64": "0.14.12",
+				"esbuild-openbsd-64": "0.14.12",
+				"esbuild-sunos-64": "0.14.12",
+				"esbuild-windows-32": "0.14.12",
+				"esbuild-windows-64": "0.14.12",
+				"esbuild-windows-arm64": "0.14.12"
+			}
+		},
+		"esbuild-android-arm64": {
+			"version": "0.14.12",
+			"resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.14.12.tgz",
+			"integrity": "sha512-eO4JHwnTeJq1/xC9K0FdHNEYztwT0HaWHnOzR5kXKwJxHatxDNZ+lCHOSxMzh9uVSmnA8YwdSiXPWbwTlWZVrw==",
+			"optional": true
+		},
+		"esbuild-darwin-64": {
+			"version": "0.14.12",
+			"resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.14.12.tgz",
+			"integrity": "sha512-LyZ81assnJWhq2IxKEVipwddKlXLTubbz/IObyKOm5cWS9jQCpuwQey2PpzroWSiy7QLGV8XCGWY5b8U8fsmWA==",
+			"optional": true
+		},
+		"esbuild-darwin-arm64": {
+			"version": "0.14.12",
+			"resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.14.12.tgz",
+			"integrity": "sha512-jj27iSbDS4KlftN1PHHNiTrtXPQIk11J/qpQiQLwKJpeEMNeJUBfQlS7X7dXgFFMxV0rNtcRl8AimEFl+qEMRQ==",
+			"optional": true
+		},
+		"esbuild-freebsd-64": {
+			"version": "0.14.12",
+			"resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.14.12.tgz",
+			"integrity": "sha512-RnTty09bA8Ts/eWnrJsYiE2dFM6ZseKYQ/7QCM5QYphU6GbifooO9oGjc/UE3Sg8R58yZVO15vnIV0i+kTgDOw==",
+			"optional": true
+		},
+		"esbuild-freebsd-arm64": {
+			"version": "0.14.12",
+			"resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.14.12.tgz",
+			"integrity": "sha512-AvAQoEgsHE53hucgoVWdHnXJBl0r9W/7eUCaBvpcgYu3W/EbPZ26VnZwfSXLpk0Pf3t7o6SRwrU+KDTKPscDTw==",
+			"optional": true
+		},
+		"esbuild-linux-32": {
+			"version": "0.14.12",
+			"resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.14.12.tgz",
+			"integrity": "sha512-na4I5i2c9ACPuglfYmrnJ6qGQnFJb59dFjyFk5OHTCtoKCq3lXbGHrvYa+3sYlOrRax1kYuRDRGse7YsDLbr3Q==",
+			"optional": true
+		},
+		"esbuild-linux-64": {
+			"version": "0.14.12",
+			"resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.14.12.tgz",
+			"integrity": "sha512-ObPoYGakJLx/RldQsFQiwsQ7N9YbQ4LLazHtpKx34bjqFjhqO5JiHPVAJYCmAtci3cJMsZ5DtEFXvijytTBz1g==",
+			"optional": true
+		},
+		"esbuild-linux-arm": {
+			"version": "0.14.12",
+			"resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.14.12.tgz",
+			"integrity": "sha512-tD4q/zVUeYkThGehYAJQElo80+ysxvq5vpd2QvykDp4hvIidEUJu2hf+NzG5OuMJSQJmAeAWPrkFOXN+6di9cA==",
+			"optional": true
+		},
+		"esbuild-linux-arm64": {
+			"version": "0.14.12",
+			"resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.14.12.tgz",
+			"integrity": "sha512-i1/ikCl9gG9yx6QuI+8yJMk9XHUu8ekIQOo6cex2pDqXY5KVHSXDTAT4FDWOd5YXQ1QTjneBAQHcKGft4pd6PQ==",
+			"optional": true
+		},
+		"esbuild-linux-mips64le": {
+			"version": "0.14.12",
+			"resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.14.12.tgz",
+			"integrity": "sha512-+/a6/tiKUCENep8ryUR75Jba4znG51Sb75OzKT6phZFEkB7fao4+GZD39Zxx3EaaA5OC10MsJPjJMFrn0dMusg==",
+			"optional": true
+		},
+		"esbuild-linux-ppc64le": {
+			"version": "0.14.12",
+			"resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.14.12.tgz",
+			"integrity": "sha512-SD7e2VLza/cEU2qKuD18Ibt1V0h3TUuerC1Mp3jRJ4RRGXWAyUt4gUpqKSiB7R0rHe6LWECdLbeVFAuGEntCeA==",
+			"optional": true
+		},
+		"esbuild-linux-s390x": {
+			"version": "0.14.12",
+			"resolved": "https://registry.npmjs.org/esbuild-linux-s390x/-/esbuild-linux-s390x-0.14.12.tgz",
+			"integrity": "sha512-KZmjYgAvYUpPBG0v6xv8qCngbfcRKC2AdYx3H3j3VqJfICgjt5XYsyG7ntWdc8Rdw9jZxr9sni6othy2Rp/T+A==",
+			"optional": true
+		},
+		"esbuild-netbsd-64": {
+			"version": "0.14.12",
+			"resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.14.12.tgz",
+			"integrity": "sha512-dG+hbCIJC65fHqzkTEYbrPSYG3m8pEaI9A1VDtqHfV13Oiw9/tua1odd47iwoWvTyurErb49wanHsIAKb8/2oQ==",
+			"optional": true
+		},
+		"esbuild-openbsd-64": {
+			"version": "0.14.12",
+			"resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.14.12.tgz",
+			"integrity": "sha512-W3SwxnMjJR3HtBD0aij5WPd0ow2bRB5BsW6FjhN7FgwDBQ+jgniFs1dq54HOkjQ2qBJrt8JvPDFAxacWjdD6Jw==",
+			"optional": true
+		},
+		"esbuild-sunos-64": {
+			"version": "0.14.12",
+			"resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.14.12.tgz",
+			"integrity": "sha512-jU/IcTFwvUtt21wOmqKJrevyHQ5XRfiCdFbPie4wsYr8VFcPZZsz18A9lcoI8gZdrF/8pBdD0V+L2UuUY0KsGg==",
+			"optional": true
+		},
+		"esbuild-windows-32": {
+			"version": "0.14.12",
+			"resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.14.12.tgz",
+			"integrity": "sha512-6luae9cmTB0rSPMCQFWMgf0SLNZ9hxusoS0poVEUHJf3n8bW6wgdyLE2xfYcEcXPMsjAt2e71/etkpqlFxeuYg==",
+			"optional": true
+		},
+		"esbuild-windows-64": {
+			"version": "0.14.12",
+			"resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.14.12.tgz",
+			"integrity": "sha512-CdCXvME/7s0uMt+4rYd8d5roHJJ5k2VDOzWaOMWExjroet+nSSZngfLpxI5St+28lXLeBorUxeBS+p1qcfEDfw==",
+			"optional": true
+		},
+		"esbuild-windows-arm64": {
+			"version": "0.14.12",
+			"resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.14.12.tgz",
+			"integrity": "sha512-vNuLQh/MpYDepK0GNpEWHy0Kn7Jf3Shz/Xetf8hUIc31jgCR1qbLVLDf3ckQdanD2U430YZupOGtEZKRwno79w==",
+			"optional": true
+		},
+		"estree-walker": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+			"integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+			"dev": true
+		},
+		"fs.realpath": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+			"dev": true
+		},
+		"fsevents": {
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+			"integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+			"dev": true,
+			"optional": true
+		},
+		"function-bind": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+			"integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+			"dev": true
+		},
+		"glob": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
+			"integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
+			"dev": true,
+			"requires": {
+				"fs.realpath": "^1.0.0",
+				"inflight": "^1.0.4",
+				"inherits": "2",
+				"minimatch": "^3.0.4",
+				"once": "^1.3.0",
+				"path-is-absolute": "^1.0.0"
+			}
+		},
+		"globalyzer": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/globalyzer/-/globalyzer-0.1.0.tgz",
+			"integrity": "sha512-40oNTM9UfG6aBmuKxk/giHn5nQ8RVz/SS4Ir6zgzOv9/qC3kKZ9v4etGTcJbEl/NyVQH7FGU7d+X1egr57Md2Q=="
+		},
+		"globrex": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/globrex/-/globrex-0.1.2.tgz",
+			"integrity": "sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg=="
+		},
+		"has": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+			"integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+			"dev": true,
+			"requires": {
+				"function-bind": "^1.1.1"
+			}
+		},
+		"inflight": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+			"dev": true,
+			"requires": {
+				"once": "^1.3.0",
+				"wrappy": "1"
+			}
+		},
+		"inherits": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+			"dev": true
+		},
+		"is-core-module": {
+			"version": "2.8.1",
+			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.8.1.tgz",
+			"integrity": "sha512-SdNCUs284hr40hFTFP6l0IfZ/RSrMXF3qgoRHd3/79unUTvrFO/JoXwkGm+5J/Oe3E/b5GsnG330uUNgRpu1PA==",
+			"dev": true,
+			"requires": {
+				"has": "^1.0.3"
+			}
+		},
+		"is-module": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-module/-/is-module-1.0.0.tgz",
+			"integrity": "sha1-Mlj7afeMFNW4FdZkM2tM/7ZEFZE=",
+			"dev": true
+		},
+		"is-reference": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/is-reference/-/is-reference-1.2.1.tgz",
+			"integrity": "sha512-U82MsXXiFIrjCK4otLT+o2NA2Cd2g5MLoOVXUZjIOhLurrRxpEXzI8O0KZHr3IjLvlAH1kTPYSuqer5T9ZVBKQ==",
+			"dev": true,
+			"requires": {
+				"@types/estree": "*"
+			}
+		},
+		"kleur": {
+			"version": "4.1.4",
+			"resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.4.tgz",
+			"integrity": "sha512-8QADVssbrFjivHWQU7KkMgptGTl6WAcSdlbBPY4uNF+mWr6DGcKrvY2w4FQJoXch7+fKMjj0dRrL75vk3k23OA==",
+			"dev": true
+		},
+		"magic-string": {
+			"version": "0.25.7",
+			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.7.tgz",
+			"integrity": "sha512-4CrMT5DOHTDk4HYDlzmwu4FVCcIYI8gauveasrdCu2IKIFOJ3f0v/8MDGJCDL9oD2ppz/Av1b0Nj345H9M+XIA==",
+			"dev": true,
+			"requires": {
+				"sourcemap-codec": "^1.4.4"
+			}
+		},
+		"minimatch": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+			"dev": true,
+			"requires": {
+				"brace-expansion": "^1.1.7"
+			}
+		},
+		"mri": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
+			"integrity": "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==",
+			"dev": true
+		},
+		"ms": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+			"dev": true
+		},
+		"nanoid": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.2.0.tgz",
+			"integrity": "sha512-fmsZYa9lpn69Ad5eDn7FMcnnSR+8R34W9qJEijxYhTbfOWzr22n1QxCMzXLK+ODyW2973V3Fux959iQoUxzUIA==",
+			"dev": true
+		},
+		"once": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+			"dev": true,
+			"requires": {
+				"wrappy": "1"
+			}
+		},
+		"path-is-absolute": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+			"dev": true
+		},
+		"path-parse": {
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+			"integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+			"dev": true
+		},
+		"picocolors": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
+			"integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
+			"dev": true
+		},
+		"picomatch": {
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+			"integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+			"dev": true
+		},
+		"postcss": {
+			"version": "8.4.5",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.5.tgz",
+			"integrity": "sha512-jBDboWM8qpaqwkMwItqTQTiFikhs/67OYVvblFFTM7MrZjt6yMKd6r2kgXizEbTTljacm4NldIlZnhbjr84QYg==",
+			"dev": true,
+			"requires": {
+				"nanoid": "^3.1.30",
+				"picocolors": "^1.0.0",
+				"source-map-js": "^1.0.1"
+			}
+		},
+		"resolve": {
+			"version": "1.21.1",
+			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.21.1.tgz",
+			"integrity": "sha512-lfEImVbnolPuaSZuLQ52cAxPBHeI77sPwCOWRdy12UG/CNa8an7oBHH1R+Fp1/mUqSJi4c8TIP6FOIPSZAUrEQ==",
+			"dev": true,
+			"requires": {
+				"is-core-module": "^2.8.0",
+				"path-parse": "^1.0.7",
+				"supports-preserve-symlinks-flag": "^1.0.0"
+			}
+		},
+		"rollup": {
+			"version": "2.66.0",
+			"resolved": "https://registry.npmjs.org/rollup/-/rollup-2.66.0.tgz",
+			"integrity": "sha512-L6mKOkdyP8HK5kKJXaiWG7KZDumPJjuo1P+cfyHOJPNNTK3Moe7zCH5+fy7v8pVmHXtlxorzaBjvkBMB23s98g==",
+			"dev": true,
+			"requires": {
+				"fsevents": "~2.3.2"
+			}
+		},
+		"sade": {
+			"version": "1.8.1",
+			"resolved": "https://registry.npmjs.org/sade/-/sade-1.8.1.tgz",
+			"integrity": "sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==",
+			"dev": true,
+			"requires": {
+				"mri": "^1.1.0"
+			}
+		},
+		"source-map-js": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
+			"integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
+			"dev": true
+		},
+		"sourcemap-codec": {
+			"version": "1.4.8",
+			"resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
+			"integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
+			"dev": true
+		},
+		"supports-preserve-symlinks-flag": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+			"integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+			"dev": true
+		},
+		"svelte": {
+			"version": "3.46.2",
+			"resolved": "https://registry.npmjs.org/svelte/-/svelte-3.46.2.tgz",
+			"integrity": "sha512-RXSAtYNefe01Sb1lXtZ2I+gzn3t/h/59hoaRNeRrm8IkMIu6BSiAkbpi41xb+C44x54YKnbk9+dtfs3pM4hECA==",
+			"dev": true,
+			"peer": true
+		},
+		"svelte-hmr": {
+			"version": "0.14.9",
+			"resolved": "https://registry.npmjs.org/svelte-hmr/-/svelte-hmr-0.14.9.tgz",
+			"integrity": "sha512-bKE9+4qb4sAnA+TKHiYurUl970rjA0XmlP9TEP7K/ncyWz3m81kA4HOgmlZK/7irGK7gzZlaPDI3cmf8fp/+tg==",
+			"dev": true,
+			"requires": {}
+		},
+		"tiny-glob": {
+			"version": "0.2.9",
+			"resolved": "https://registry.npmjs.org/tiny-glob/-/tiny-glob-0.2.9.tgz",
+			"integrity": "sha512-g/55ssRPUjShh+xkfx9UPDXqhckHEsHr4Vd9zX55oSdGZc/MD0m3sferOkwWtp98bv+kcVfEHtRJgBVJzelrzg==",
+			"requires": {
+				"globalyzer": "0.1.0",
+				"globrex": "^0.1.2"
+			}
+		},
+		"typescript": {
+			"version": "4.5.5",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
+			"integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
+			"dev": true
+		},
+		"vite": {
+			"version": "2.7.13",
+			"resolved": "https://registry.npmjs.org/vite/-/vite-2.7.13.tgz",
+			"integrity": "sha512-Mq8et7f3aK0SgSxjDNfOAimZGW9XryfHRa/uV0jseQSilg+KhYDSoNb9h1rknOy6SuMkvNDLKCYAYYUMCE+IgQ==",
+			"dev": true,
+			"requires": {
+				"esbuild": "^0.13.12",
+				"fsevents": "~2.3.2",
+				"postcss": "^8.4.5",
+				"resolve": "^1.20.0",
+				"rollup": "^2.59.0"
+			},
+			"dependencies": {
+				"esbuild": {
+					"version": "0.13.15",
+					"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.13.15.tgz",
+					"integrity": "sha512-raCxt02HBKv8RJxE8vkTSCXGIyKHdEdGfUmiYb8wnabnaEmHzyW7DCHb5tEN0xU8ryqg5xw54mcwnYkC4x3AIw==",
+					"dev": true,
+					"requires": {
+						"esbuild-android-arm64": "0.13.15",
+						"esbuild-darwin-64": "0.13.15",
+						"esbuild-darwin-arm64": "0.13.15",
+						"esbuild-freebsd-64": "0.13.15",
+						"esbuild-freebsd-arm64": "0.13.15",
+						"esbuild-linux-32": "0.13.15",
+						"esbuild-linux-64": "0.13.15",
+						"esbuild-linux-arm": "0.13.15",
+						"esbuild-linux-arm64": "0.13.15",
+						"esbuild-linux-mips64le": "0.13.15",
+						"esbuild-linux-ppc64le": "0.13.15",
+						"esbuild-netbsd-64": "0.13.15",
+						"esbuild-openbsd-64": "0.13.15",
+						"esbuild-sunos-64": "0.13.15",
+						"esbuild-windows-32": "0.13.15",
+						"esbuild-windows-64": "0.13.15",
+						"esbuild-windows-arm64": "0.13.15"
+					}
+				},
+				"esbuild-android-arm64": {
+					"version": "0.13.15",
+					"resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.13.15.tgz",
+					"integrity": "sha512-m602nft/XXeO8YQPUDVoHfjyRVPdPgjyyXOxZ44MK/agewFFkPa8tUo6lAzSWh5Ui5PB4KR9UIFTSBKh/RrCmg==",
+					"dev": true,
+					"optional": true
+				},
+				"esbuild-darwin-64": {
+					"version": "0.13.15",
+					"resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.13.15.tgz",
+					"integrity": "sha512-ihOQRGs2yyp7t5bArCwnvn2Atr6X4axqPpEdCFPVp7iUj4cVSdisgvEKdNR7yH3JDjW6aQDw40iQFoTqejqxvQ==",
+					"dev": true,
+					"optional": true
+				},
+				"esbuild-darwin-arm64": {
+					"version": "0.13.15",
+					"resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.13.15.tgz",
+					"integrity": "sha512-i1FZssTVxUqNlJ6cBTj5YQj4imWy3m49RZRnHhLpefFIh0To05ow9DTrXROTE1urGTQCloFUXTX8QfGJy1P8dQ==",
+					"dev": true,
+					"optional": true
+				},
+				"esbuild-freebsd-64": {
+					"version": "0.13.15",
+					"resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.13.15.tgz",
+					"integrity": "sha512-G3dLBXUI6lC6Z09/x+WtXBXbOYQZ0E8TDBqvn7aMaOCzryJs8LyVXKY4CPnHFXZAbSwkCbqiPuSQ1+HhrNk7EA==",
+					"dev": true,
+					"optional": true
+				},
+				"esbuild-freebsd-arm64": {
+					"version": "0.13.15",
+					"resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.13.15.tgz",
+					"integrity": "sha512-KJx0fzEDf1uhNOZQStV4ujg30WlnwqUASaGSFPhznLM/bbheu9HhqZ6mJJZM32lkyfGJikw0jg7v3S0oAvtvQQ==",
+					"dev": true,
+					"optional": true
+				},
+				"esbuild-linux-32": {
+					"version": "0.13.15",
+					"resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.13.15.tgz",
+					"integrity": "sha512-ZvTBPk0YWCLMCXiFmD5EUtB30zIPvC5Itxz0mdTu/xZBbbHJftQgLWY49wEPSn2T/TxahYCRDWun5smRa0Tu+g==",
+					"dev": true,
+					"optional": true
+				},
+				"esbuild-linux-64": {
+					"version": "0.13.15",
+					"resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.13.15.tgz",
+					"integrity": "sha512-eCKzkNSLywNeQTRBxJRQ0jxRCl2YWdMB3+PkWFo2BBQYC5mISLIVIjThNtn6HUNqua1pnvgP5xX0nHbZbPj5oA==",
+					"dev": true,
+					"optional": true
+				},
+				"esbuild-linux-arm": {
+					"version": "0.13.15",
+					"resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.13.15.tgz",
+					"integrity": "sha512-wUHttDi/ol0tD8ZgUMDH8Ef7IbDX+/UsWJOXaAyTdkT7Yy9ZBqPg8bgB/Dn3CZ9SBpNieozrPRHm0BGww7W/jA==",
+					"dev": true,
+					"optional": true
+				},
+				"esbuild-linux-arm64": {
+					"version": "0.13.15",
+					"resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.13.15.tgz",
+					"integrity": "sha512-bYpuUlN6qYU9slzr/ltyLTR9YTBS7qUDymO8SV7kjeNext61OdmqFAzuVZom+OLW1HPHseBfJ/JfdSlx8oTUoA==",
+					"dev": true,
+					"optional": true
+				},
+				"esbuild-linux-mips64le": {
+					"version": "0.13.15",
+					"resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.13.15.tgz",
+					"integrity": "sha512-KlVjIG828uFPyJkO/8gKwy9RbXhCEUeFsCGOJBepUlpa7G8/SeZgncUEz/tOOUJTcWMTmFMtdd3GElGyAtbSWg==",
+					"dev": true,
+					"optional": true
+				},
+				"esbuild-linux-ppc64le": {
+					"version": "0.13.15",
+					"resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.13.15.tgz",
+					"integrity": "sha512-h6gYF+OsaqEuBjeesTBtUPw0bmiDu7eAeuc2OEH9S6mV9/jPhPdhOWzdeshb0BskRZxPhxPOjqZ+/OqLcxQwEQ==",
+					"dev": true,
+					"optional": true
+				},
+				"esbuild-netbsd-64": {
+					"version": "0.13.15",
+					"resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.13.15.tgz",
+					"integrity": "sha512-3+yE9emwoevLMyvu+iR3rsa+Xwhie7ZEHMGDQ6dkqP/ndFzRHkobHUKTe+NCApSqG5ce2z4rFu+NX/UHnxlh3w==",
+					"dev": true,
+					"optional": true
+				},
+				"esbuild-openbsd-64": {
+					"version": "0.13.15",
+					"resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.13.15.tgz",
+					"integrity": "sha512-wTfvtwYJYAFL1fSs8yHIdf5GEE4NkbtbXtjLWjM3Cw8mmQKqsg8kTiqJ9NJQe5NX/5Qlo7Xd9r1yKMMkHllp5g==",
+					"dev": true,
+					"optional": true
+				},
+				"esbuild-sunos-64": {
+					"version": "0.13.15",
+					"resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.13.15.tgz",
+					"integrity": "sha512-lbivT9Bx3t1iWWrSnGyBP9ODriEvWDRiweAs69vI+miJoeKwHWOComSRukttbuzjZ8r1q0mQJ8Z7yUsDJ3hKdw==",
+					"dev": true,
+					"optional": true
+				},
+				"esbuild-windows-32": {
+					"version": "0.13.15",
+					"resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.13.15.tgz",
+					"integrity": "sha512-fDMEf2g3SsJ599MBr50cY5ve5lP1wyVwTe6aLJsM01KtxyKkB4UT+fc5MXQFn3RLrAIAZOG+tHC+yXObpSn7Nw==",
+					"dev": true,
+					"optional": true
+				},
+				"esbuild-windows-64": {
+					"version": "0.13.15",
+					"resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.13.15.tgz",
+					"integrity": "sha512-9aMsPRGDWCd3bGjUIKG/ZOJPKsiztlxl/Q3C1XDswO6eNX/Jtwu4M+jb6YDH9hRSUflQWX0XKAfWzgy5Wk54JQ==",
+					"dev": true,
+					"optional": true
+				},
+				"esbuild-windows-arm64": {
+					"version": "0.13.15",
+					"resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.13.15.tgz",
+					"integrity": "sha512-zzvyCVVpbwQQATaf3IG8mu1IwGEiDxKkYUdA4FpoCHi1KtPa13jeScYDjlW0Qh+ebWzpKfR2ZwvqAQkSWNcKjA==",
+					"dev": true,
+					"optional": true
+				}
+			}
+		},
+		"wrappy": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+			"dev": true
+		}
+	}
+}

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
-	"name": "svelte-adapter-deno-mini",
+	"name": "svelte-adapter-deno-deploy",
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/TheHadiAhmadi/svelte-adapter-deno.git"
 	},
-	"version": "0.5.6",
+	"version": "0.5.7",
 	"type": "module",
 	"exports": {
 		"import": "./index.js"

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
 		"type": "git",
 		"url": "https://github.com/TheHadiAhmadi/svelte-adapter-deno.git"
 	},
-	"version": "0.5.1",
+	"version": "0.5.2",
 	"type": "module",
 	"exports": {
 		"import": "./index.js"

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
 		"type": "git",
 		"url": "https://github.com/TheHadiAhmadi/svelte-adapter-deno.git"
 	},
-	"version": "0.5.2",
+	"version": "0.5.3",
 	"type": "module",
 	"exports": {
 		"import": "./index.js"

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
 		"type": "git",
 		"url": "https://github.com/TheHadiAhmadi/svelte-adapter-deno.git"
 	},
-	"version": "0.5.4",
+	"version": "0.5.5",
 	"type": "module",
 	"exports": {
 		"import": "./index.js"

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
-	"name": "svelte-adapter-deno",
+	"name": "svelte-adapter-deno-mini",
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/pluvial/svelte-adapter-deno.git"
+		"url": "https://github.com/TheHadiAhmadi/svelte-adapter-deno.git"
 	},
 	"version": "0.5.0",
 	"type": "module",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
 		"type": "git",
 		"url": "https://github.com/TheHadiAhmadi/svelte-adapter-deno.git"
 	},
-	"version": "0.5.3",
+	"version": "0.5.4",
 	"type": "module",
 	"exports": {
 		"import": "./index.js"

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
 		"type": "git",
 		"url": "https://github.com/TheHadiAhmadi/svelte-adapter-deno.git"
 	},
-	"version": "0.5.7",
+	"version": "0.5.8",
 	"type": "module",
 	"exports": {
 		"import": "./index.js"

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
 		"type": "git",
 		"url": "https://github.com/TheHadiAhmadi/svelte-adapter-deno.git"
 	},
-	"version": "0.5.5",
+	"version": "0.5.6",
 	"type": "module",
 	"exports": {
 		"import": "./index.js"

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
 		"type": "git",
 		"url": "https://github.com/TheHadiAhmadi/svelte-adapter-deno.git"
 	},
-	"version": "0.5.8",
+	"version": "0.5.9",
 	"type": "module",
 	"exports": {
 		"import": "./index.js"

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
 		"type": "git",
 		"url": "https://github.com/TheHadiAhmadi/svelte-adapter-deno.git"
 	},
-	"version": "0.5.0",
+	"version": "0.5.1",
 	"type": "module",
 	"exports": {
 		"import": "./index.js"

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -2,13 +2,23 @@ import { nodeResolve } from '@rollup/plugin-node-resolve';
 import commonjs from '@rollup/plugin-commonjs';
 import json from '@rollup/plugin-json';
 
-export default {
-	input: 'src/index.js',
+export default [{
+	input: 'src/handler.js',
 	output: {
-		file: 'files/index.js',
+		file: 'files/handler.js',
 		format: 'esm',
 		sourcemap: true
 	},
 	plugins: [nodeResolve(), commonjs(), json()],
 	external: ['../output/server/app.js', './deps.ts', ...require('module').builtinModules]
-};
+}, {
+	input: 'src/server.js',
+	output: {
+		file: 'files/server.js',
+		format: 'esm',
+		sourcemap: true
+	},
+	plugins: [nodeResolve(), commonjs(), json()],
+
+	external: ['../output/server/app.js', './deps.ts', './handler.js', ...require('module').builtinModules]
+}];

--- a/src/handler.js
+++ b/src/handler.js
@@ -18,7 +18,7 @@ const prefix = `/${manifest.appDir}/`;
  * @returns {Promise<Response>}
  */
  async function sendFile(request, path, file) {
-	const filename = join("/src/build", path, file);
+	const filename = join("./build", path, file);
   
 	const data = await Deno.readFile(filename);
 	return new Response(data, {

--- a/src/handler.js
+++ b/src/handler.js
@@ -1,4 +1,4 @@
-import { dirname, serveFile, fromFileUrl, join, readAll, readerFromStreamReader } from './deps.ts';
+import { dirname, fromFileUrl, join} from './deps.ts';
 
 import { App } from 'APP';
 import { manifest, prerendered } from 'MANIFEST';
@@ -17,8 +17,8 @@ const prefix = `/${manifest.appDir}/`;
  * @param {string} file it can be nested in sub folders too
  * @returns {Promise<Response>}
  */
- async function sendFile(request, path2, file) {
-	const filename = join("/src/build", path2, file);
+ async function sendFile(request, path, file) {
+	const filename = join("/src/build", path, file);
   
 	const data = await Deno.readFile(filename);
 	return new Response(data, {
@@ -34,7 +34,7 @@ const prefix = `/${manifest.appDir}/`;
  * @param {Request} request original request object
  * @returns {Promise<Response>}
  */
-export async function handler(request) {
+export default async function handler(request) {
 	// generated assets
 	const url = new URL(request.url)
 	if (url.pathname.startsWith(prefix)) {

--- a/src/handler.js
+++ b/src/handler.js
@@ -1,5 +1,6 @@
 import { dirname, fromFileUrl, join} from './deps.ts';
 
+// to prevent an error
 window.navigator.userAgent = []
 
 
@@ -18,7 +19,7 @@ const prefix = `/${manifest.appDir}/`;
  * @param {string} file it can be nested in sub folders too
  * @returns {Promise<Response>}
  */
- async function sendFile(request, path, file) {
+ async function sendFile(path, file) {
 	const filename = join('FILES_PREFIX', path, file);
 
 	const data = await Deno.readFile(filename);
@@ -38,7 +39,7 @@ export default async function handler(request) {
 	// generated assets
 	const url = new URL(request.url)
 	if (url.pathname.startsWith(prefix)) {
-		const response = await sendFile(request, 'client', url.pathname)
+		const response = await sendFile('client', url.pathname)
 		response.headers.append('cache-control', 'public, immutable, max-age=31536000')
 		return response;
 	}
@@ -54,14 +55,14 @@ export default async function handler(request) {
 	}
 
 	if (manifest.assets.has(file)) {
-		return await sendFile(request, 'static', file);
+		return await sendFile('static', file);
 	}
 	file += '/index.html';
 	if (manifest.assets.has(file)) {
-		return await sendFile(request, 'static', file);
+		return await sendFile('static', file);
 	}
 	if (prerendered.has(pathname || '/')) {
-		return await sendFile(request, 'prerendered', file);
+		return await sendFile('prerendered', file);
 	}
 
 	const rendered = await app.render(request);

--- a/src/handler.js
+++ b/src/handler.js
@@ -19,7 +19,7 @@ const prefix = `/${manifest.appDir}/`;
  * @returns {Promise<Response>}
  */
  async function sendFile(request, path, file) {
-	const filename = join(FILES_PREFIX, path, file);
+	const filename = join('FILES_PREFIX', path, file);
 
 	const data = await Deno.readFile(filename);
 	return new Response(data, {

--- a/src/handler.js
+++ b/src/handler.js
@@ -22,11 +22,11 @@ const prefix = `/${manifest.appDir}/`;
  async function sendFile(path, file) {
 	const filename = join('FILES_PREFIX', path, file);
 
-	const data = await Deno.readFile(filename);
-	return new Response(data, {
+	const data = await fetch(filename);
+	return new Response(data.body, {
 	  status: 200,
 	  headers: {
-		"Content-Type": contentType(filename),
+			"Content-Type": contentType(filename),
 	  },
 	});
   }

--- a/src/handler.js
+++ b/src/handler.js
@@ -17,7 +17,7 @@ const prefix = `/${manifest.appDir}/`;
  * @param {Request} request original request object
  * @returns {Promise<Response>}
  */
-export default async function handler(request) {
+export default async function handler(request, platform = {}) {
 	// generated assets
 	const url = new URL(request.url)
 	if (url.pathname.startsWith(prefix)) {
@@ -47,7 +47,7 @@ export default async function handler(request) {
 		return await serveFile(request, join('FILES_PREFIX', 'prerendered', file));
 	}
 
-	const rendered = await app.render(request);
+	const rendered = await app.render(request, { platform } );
 
 	if (rendered) {
 		return rendered

--- a/src/handler.js
+++ b/src/handler.js
@@ -19,8 +19,8 @@ const prefix = `/${manifest.appDir}/`;
  * @returns {Promise<Response>}
  */
  async function sendFile(request, path, file) {
-	const filename = join("./build", path, file);
-  
+	const filename = join(FILES_PREFIX, path, file);
+
 	const data = await Deno.readFile(filename);
 	return new Response(data, {
 	  status: 200,
@@ -64,11 +64,7 @@ export default async function handler(request) {
 		return await sendFile(request, 'prerendered', file);
 	}
 
-	// dynamically-generated pages
-
 	const rendered = await app.render(request);
-
-
 
 	if (rendered) {
 		return rendered

--- a/src/handler.js
+++ b/src/handler.js
@@ -1,12 +1,13 @@
 import { dirname, fromFileUrl, join} from './deps.ts';
 
+window.navigator.userAgent = []
+
+
 import { App } from 'APP';
 import { manifest, prerendered } from 'MANIFEST';
 import { contentType } from './content-types';
 
 const app = new App(manifest);
-
-const __dirname = dirname(fromFileUrl(import.meta.url));
 
 const prefix = `/${manifest.appDir}/`;
 
@@ -27,7 +28,6 @@ const prefix = `/${manifest.appDir}/`;
 		"Content-Type": contentType(filename),
 	  },
 	});
-	// return await serveFile(request, filename);
   }
 /**
  * 

--- a/src/handler.js
+++ b/src/handler.js
@@ -2,6 +2,7 @@ import { dirname, serveFile, fromFileUrl, join, readAll, readerFromStreamReader 
 
 import { App } from 'APP';
 import { manifest, prerendered } from 'MANIFEST';
+import { contentType } from './content-types';
 
 const app = new App(manifest);
 
@@ -16,10 +17,18 @@ const prefix = `/${manifest.appDir}/`;
  * @param {string} file it can be nested in sub folders too
  * @returns {Promise<Response>}
  */
-async function sendFile(request, path, file) {
-	const filename = join(__dirname, path, file)
-	return await serveFile(request, filename) 
-}
+ async function sendFile(request, path2, file) {
+	const filename = join("/src/build", path2, file);
+  
+	const data = await Deno.readFile(filename);
+	return new Response(data, {
+	  status: 200,
+	  headers: {
+		"Content-Type": contentType(filename),
+	  },
+	});
+	// return await serveFile(request, filename);
+  }
 /**
  * 
  * @param {Request} request original request object

--- a/src/server.js
+++ b/src/server.js
@@ -1,14 +1,11 @@
-import handler from './handler.js';
+import handler from './build/handler.js';
 
-let path = Deno.env.get(PATH_ENV) ?? false;
-let host = Deno.env.get(HOST_ENV) ?? '0.0.0.0';
-let port = Deno.env.get(PORT_ENV) ?? (!path && 3000);
+const port = Deno.env.get('PORT') ?? 3000;
 
-if (path) {
-	host = path.split(':')[0];
-	port = Number(path.split(':')[1]);
-}
-const server = Deno.listen({ port: port, hostname: host });
+const hostname = Deno.env.get('HOST') ?? 'localhost';
+
+const server = Deno.listen({ port, hostname });
+console.log(`server is running at ${hostname}:${port}`);
 
 for await (const conn of server) {
 	for await (const { request, respondWith } of Deno.serveHttp(conn)) {

--- a/src/server.js
+++ b/src/server.js
@@ -1,8 +1,8 @@
-import { handler } from './handler.js';
+import handler from './handler.js';
 
-export let path = Deno.env.get(PATH_ENV) ?? false;
-export let host = Deno.env.get(HOST_ENV) ?? '0.0.0.0';
-export let port = Deno.env.get(PORT_ENV) ?? (!path && 3000);
+let path = Deno.env.get(PATH_ENV) ?? false;
+let host = Deno.env.get(HOST_ENV) ?? '0.0.0.0';
+let port = Deno.env.get(PORT_ENV) ?? (!path && 3000);
 
 if (path) {
 	host = path.split(':')[0];
@@ -15,5 +15,3 @@ for await (const conn of server) {
 		respondWith(handler(request));
 	}
 }
-
-export { server };

--- a/src/server.js
+++ b/src/server.js
@@ -8,6 +8,14 @@ console.log(`server is running at ${hostname}:${port}`);
 
 for await (const conn of server) {
 	for await (const { request, respondWith } of Deno.serveHttp(conn)) {
-		respondWith(handler(request));
+		respondWith(handler(request, {
+			// example
+			db: {
+				get() { console.log("Get All")},
+				insert(data) { console.log('insert',  data)},
+				update(filter, data) { console.log("update",  filter, data)},
+				delete(filter) { console.log("Delete: ", filter)}
+			}
+		}));
 	}
 }

--- a/src/server.js
+++ b/src/server.js
@@ -1,7 +1,6 @@
-import handler from './build/handler.js';
+import handler from './handler.js';
 
 const port = Deno.env.get('PORT') ?? 3000;
-
 const hostname = Deno.env.get('HOST') ?? 'localhost';
 
 const server = Deno.listen({ port, hostname });

--- a/src/server.js
+++ b/src/server.js
@@ -8,14 +8,8 @@ console.log(`server is running at ${hostname}:${port}`);
 
 for await (const conn of server) {
 	for await (const { request, respondWith } of Deno.serveHttp(conn)) {
-		respondWith(handler(request, {
-			// example
-			db: {
-				get() { console.log("Get All")},
-				insert(data) { console.log('insert',  data)},
-				update(filter, data) { console.log("update",  filter, data)},
-				delete(filter) { console.log("Delete: ", filter)}
-			}
+		respondWith(handler(request, { 
+			/*everything passed here, will be available as `platform` in sveltekit*/ 
 		}));
 	}
 }

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,7 +1,7 @@
 declare global {
-	const PATH_ENV: string;
 	const HOST_ENV: string;
 	const PORT_ENV: string;
+	const FILES_PREFIX: string;
 }
 
 export {};


### PR DESCRIPTION
Hello @jpaquim 

in this PR I changed many files and structure of package canged, feel free to close if it is not helpful

I added 2 more config options 
1. serverFile: this is not used but if we provide serverFile then we will only generate handler.js and not server.js
2. filesPrefix: relative path from server.js to static and client files, this is useful when we set `serverFile` to a file which is in another folder. (we can merge these options and only use serverFile and calculate filesPrefix based on build folder and server file).

I tested it with `@supabase/supabase-js` and `@popperjs/core` and works fine on deno deploy

thanks     